### PR TITLE
fix: escape HTML in component reference table

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,32 +59,32 @@ Auto-generated from `src/components/` exports. Each component carries a `.meta` 
 
 | Component | Output |
 | --- | --- |
-| `<Align align="center">...</Align>` | <p align="..."> |
+| `<Align align="center">...</Align>` | &lt;p align="..."&gt; |
 | `<Badge label=... value=... />` | shields.io badge |
 | `<Badges>...</Badges>` | Badge row with spacing |
-| `<Blockquote>text</Blockquote>` | > text |
+| `<Blockquote>text</Blockquote>` | &gt; text |
 | `<Bold>text</Bold>` | **text** |
 | `<Cell>text</Cell>` | Table cell content |
-| `<Center>...</Center>` | <div align="center"> |
+| `<Center>...</Center>` | &lt;div align="center"&gt; |
 | `<Code>text</Code>` | `` `text` `` |
 | `<CodeBlock lang="bash">...</CodeBlock>` | Fenced code block |
 | `<Details summary=...>...</Details>` | Collapsible section |
 | `<HR />` | --- |
 | `<Heading level={2}>Title</Heading>` | ## Title |
-| `<HtmlLink href="url">text</HtmlLink>` | <a> tag |
-| `<HtmlTable>...</HtmlTable>` | <table> for layout |
-| `<HtmlTd width=... valign=...>` | <td> cell with optional sizing |
-| `<HtmlTr>...</HtmlTr>` | <tr> row |
+| `<HtmlLink href="url">text</HtmlLink>` | &lt;a&gt; tag |
+| `<HtmlTable>...</HtmlTable>` | &lt;table&gt; for layout |
+| `<HtmlTd width=... valign=...>` | &lt;td&gt; cell with optional sizing |
+| `<HtmlTr>...</HtmlTr>` | &lt;tr&gt; row |
 | `<Image src="..." alt="..." />` | ![alt](src) or HTML with width |
 | `<Italic>text</Italic>` | *text* |
 | `<Item>text</Item>` | List item content |
-| `<LineBreak />` | <br /> |
+| `<LineBreak />` | &lt;br /&gt; |
 | `<Link href="url">text</Link>` | [text](url) |
 | `<List><Item>...</Item></List>` | Bulleted or numbered list |
 | `<Paragraph>Text</Paragraph>` | Text with trailing blank line |
 | `<Raw>html</Raw>` | HTML passthrough |
 | `<Section title=... level=...>` | Heading + content block |
-| `<Sub>text</Sub>` | <sub> tag |
+| `<Sub>text</Sub>` | &lt;sub&gt; tag |
 | `<Table>...</Table>` | GFM table wrapper |
 | `<TableHead><Cell>...</Cell></TableHead>` | Header row + separator |
 | `<TableRow><Cell>...</Cell></TableRow>` | Table data row |

--- a/README.tsx
+++ b/README.tsx
@@ -13,6 +13,7 @@ import {
 
 import type { ComponentMeta } from "./src/components";
 import * as allComponents from "./src/components";
+import { escapeHtml } from "./src/components/helpers";
 
 // Build component reference from exports — each export with .meta is documented,
 // those without are shown with a warning
@@ -106,7 +107,7 @@ readme build --check      # Exit 1 if README.md is stale (for CI)`}</CodeBlock>
         {componentRows.map(row => (
           <TableRow>
             <Cell><Code>{row.usage}</Code></Cell>
-            <Cell>{row.output}</Cell>
+            <Cell>{escapeHtml(row.output)}</Cell>
           </TableRow>
         ))}
       </Table>

--- a/src/components.test.tsx
+++ b/src/components.test.tsx
@@ -10,6 +10,7 @@ import {
   Section,
   box, labeledBox, sideBySide,
 } from "./components";
+import { escapeHtml } from "./components/helpers";
 
 // --- Inline elements ---
 
@@ -334,6 +335,67 @@ describe("composition", () => {
       "| a | first |\n" +
       "| b | second |\n\n"
     );
+  });
+});
+
+// --- Helpers ---
+
+describe("escapeHtml", () => {
+  test("escapes angle brackets", () => {
+    expect(escapeHtml("<table>")).toBe("&lt;table&gt;");
+  });
+
+  test("escapes ampersands", () => {
+    expect(escapeHtml("a & b")).toBe("a &amp; b");
+  });
+
+  test("escapes ampersands before angle brackets", () => {
+    expect(escapeHtml("&lt;")).toBe("&amp;lt;");
+  });
+
+  test("passes through plain text unchanged", () => {
+    expect(escapeHtml("hello world")).toBe("hello world");
+  });
+
+  test("handles empty string", () => {
+    expect(escapeHtml("")).toBe("");
+  });
+
+  test("escapes complex HTML", () => {
+    expect(escapeHtml('<div align="center">')).toBe('&lt;div align="center"&gt;');
+  });
+});
+
+// --- Table cells with HTML content (regression) ---
+
+describe("table with HTML in cells", () => {
+  test("escaped HTML in cells does not break table structure", () => {
+    const result = (
+      <Table>
+        <TableHead>
+          <Cell>Component</Cell>
+          <Cell>Output</Cell>
+        </TableHead>
+        <TableRow>
+          <Cell><Code>{"<Center>...</Center>"}</Code></Cell>
+          <Cell>{escapeHtml('<div align="center">')}</Cell>
+        </TableRow>
+        <TableRow>
+          <Cell><Code>{"<HtmlTable>...</HtmlTable>"}</Code></Cell>
+          <Cell>{escapeHtml("<table> for layout")}</Cell>
+        </TableRow>
+      </Table>
+    );
+    // Escaped HTML should not contain raw tags
+    expect(result).not.toContain("| <div");
+    expect(result).not.toContain("| <table>");
+    expect(result).toContain("&lt;div");
+    expect(result).toContain("&lt;table&gt;");
+    // Table structure should be intact — exactly 4 lines (header, separator, 2 rows)
+    // plus trailing newline
+    const lines = result.trimEnd().split("\n");
+    expect(lines).toHaveLength(4);
+    expect(lines.every(l => l.startsWith("|") && l.endsWith("|"))).toBe(true);
   });
 });
 

--- a/src/components/helpers.ts
+++ b/src/components/helpers.ts
@@ -7,6 +7,10 @@ export function flatten(c: any): string {
   return String(c);
 }
 
+export function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 export function shieldsEncode(s: string): string {
   return encodeURIComponent(s).replaceAll("-", "--").replaceAll("_", "__");
 }


### PR DESCRIPTION
## Summary

- Raw HTML tags (`<table>`, `<div>`, `<p>`, `<a>`, `<br />`, etc.) in the Output column of the component reference table were interpreted by GitHub's GFM parser as actual HTML, breaking the table structure and absorbing all subsequent sections ("Why JSX?", "Development", "License") into the last table cell.
- Added `escapeHtml()` helper to `src/components/helpers.ts` and applied it to `row.output` in `README.tsx`.
- 8 new tests (6 unit + 1 regression), 60 total passing, `build --check` clean.

## Test plan

- [x] `bun test` — 60/60 passing
- [x] `mise run build --check` — README.md is up to date
- [ ] Verify on GitHub that the component table renders correctly with no content leaking out of the table