### PR TITLE
feat: Rule and RuleSet components for LaTeX inference rules

### DIFF
--- a/src/components.test.tsx
+++ b/src/components.test.tsx
@@ -11,8 +11,9 @@ import {
   Section,
   Alert,
   box, labeledBox, sideBySide,
+  Rule, RuleSet,
 } from "./components";
-import { escapeHtml } from "./components/helpers";
+import { escapeHtml, unicodeToLatex } from "./components/helpers";
 
 // --- Inline elements ---
 
@@ -618,5 +619,123 @@ describe("Chat", () => {
     expect(result).toContain("**bob**");
     expect(result).toContain("> hi");
     expect(result).toContain("> hey");
+  });
+});
+
+// --- unicodeToLatex helper ---
+
+describe("unicodeToLatex", () => {
+  test("converts angle brackets", () => {
+    expect(unicodeToLatex("⟨A⟩")).toBe("\\langle A\\rangle ");
+  });
+
+  test("converts Downarrow", () => {
+    expect(unicodeToLatex("⇓")).toBe("\\Downarrow ");
+  });
+
+  test("converts sigma", () => {
+    expect(unicodeToLatex("σ")).toBe("\\sigma");
+  });
+
+  test("converts && to mathbin", () => {
+    expect(unicodeToLatex("A && B")).toBe("A \\mathbin{\\&\\&} B");
+  });
+
+  test("leaves plain text unchanged", () => {
+    expect(unicodeToLatex("hello")).toBe("hello");
+  });
+
+  test("converts a realistic premise string", () => {
+    const result = unicodeToLatex("⟨A, σ⟩ ⇓ (0, σ')");
+    expect(result).toContain("\\langle");
+    expect(result).toContain("\\rangle");
+    expect(result).toContain("\\Downarrow");
+    expect(result).toContain("\\sigma");
+  });
+});
+
+// --- Rule component ---
+
+describe("Rule", () => {
+  test("renders a math fenced block", () => {
+    const result = <Rule premises={["A"]} conclusion="B" />;
+    expect(result).toStartWith("```math\n");
+    expect(result).toContain("\\frac{A}{B}");
+    expect(result).toEndWith("```\n\n");
+  });
+
+  test("appends name label when provided", () => {
+    const result = <Rule premises={["A"]} conclusion="B" name="MyRule" />;
+    expect(result).toContain("\\text{ (MyRule)}");
+  });
+
+  test("omits label when name is not provided", () => {
+    const result = <Rule premises={["A"]} conclusion="B" />;
+    expect(result).not.toContain("\\text");
+  });
+
+  test("joins multiple premises with \\quad", () => {
+    const result = <Rule premises={["P1", "P2", "P3"]} conclusion="C" />;
+    expect(result).toContain("P1 \\quad P2 \\quad P3");
+  });
+
+  test("converts Unicode symbols in premises and conclusion", () => {
+    const result = <Rule
+      premises={["⟨A, σ⟩ ⇓ (0, σ')"]}
+      conclusion="⟨A && B, σ⟩ ⇓ (0, σ')"
+      name="And-Success"
+    />;
+    expect(result).toContain("\\langle");
+    expect(result).toContain("\\Downarrow");
+    expect(result).toContain("\\sigma");
+    expect(result).toContain("\\mathbin{\\&\\&}");
+    expect(result).toContain("\\text{ (And-Success)}");
+  });
+
+  test("renders exact output from issue example", () => {
+    const result = <Rule
+      premises={["⟨A, σ⟩ ⇓ (0, σ')", "⟨B, σ'⟩ ⇓ (n, σ'')"]}
+      conclusion="⟨A && B, σ⟩ ⇓ (n, σ'')"
+      name="And-Success"
+    />;
+    expect(result).toStartWith("```math\n\\frac{");
+    expect(result).toContain("\\quad");
+    expect(result).toContain("\\text{ (And-Success)}");
+    expect(result).toEndWith("```\n\n");
+  });
+});
+
+// --- RuleSet component ---
+
+describe("RuleSet", () => {
+  test("renders children without a title", () => {
+    const result = (
+      <RuleSet>
+        <Rule premises={["A"]} conclusion="B" />
+      </RuleSet>
+    );
+    expect(result).not.toContain("##");
+    expect(result).toContain("\\frac{A}{B}");
+  });
+
+  test("renders heading when title is provided", () => {
+    const result = (
+      <RuleSet title="Evaluation Rules">
+        <Rule premises={["A"]} conclusion="B" />
+      </RuleSet>
+    );
+    expect(result).toStartWith("## Evaluation Rules\n\n");
+    expect(result).toContain("\\frac{A}{B}");
+  });
+
+  test("groups multiple rules", () => {
+    const result = (
+      <RuleSet title="Rules">
+        <Rule premises={["A"]} conclusion="B" name="R1" />
+        <Rule premises={["C"]} conclusion="D" name="R2" />
+      </RuleSet>
+    );
+    expect(result).toContain("\\text{ (R1)}");
+    expect(result).toContain("\\text{ (R2)}");
   });
 });

--- a/src/components/helpers.ts
+++ b/src/components/helpers.ts
@@ -14,3 +14,18 @@ export function escapeHtml(s: string): string {
 export function shieldsEncode(s: string): string {
   return encodeURIComponent(s).replaceAll("-", "--").replaceAll("_", "__");
 }
+
+const UNICODE_TO_LATEX: [RegExp, string][] = [
+  [/&&/g, "\\mathbin{\\&\\&}"],
+  [/⟨/g, "\\langle "],
+  [/⟩/g, "\\rangle "],
+  [/⇓/g, "\\Downarrow "],
+  [/⇑/g, "\\Uparrow "],
+  [/≠/g, "\\neq "],
+  [/∈/g, "\\in "],
+  [/σ/g, "\\sigma"],
+];
+
+export function unicodeToLatex(s: string): string {
+  return UNICODE_TO_LATEX.reduce((acc, [re, latex]) => acc.replace(re, latex), s);
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,5 +20,6 @@ export { Raw, HtmlLink, Sub, HtmlTable, HtmlTr, HtmlTd } from "./html";
 export { Badge, Badges } from "./badges";
 export { Alert } from "./alert";
 export { Chat, Message } from "./chat";
+export { Rule, RuleSet } from "./math";
 export type { BoxStyle } from "./box";
 export { box, labeledBox, sideBySide } from "./box";

--- a/src/components/math.tsx
+++ b/src/components/math.tsx
@@ -1,0 +1,30 @@
+import type { ComponentMeta } from "./types";
+import { flatten, unicodeToLatex } from "./helpers";
+
+export function Rule({
+  premises,
+  conclusion,
+  name,
+}: {
+  premises: string[];
+  conclusion: string;
+  name?: string;
+}) {
+  const latexPremises = premises.map(unicodeToLatex).join(" \\quad ");
+  const latexConclusion = unicodeToLatex(conclusion);
+  const label = name ? ` \\text{ (${name})}` : "";
+  return `\`\`\`math\n\\frac{${latexPremises}}{${latexConclusion}}${label}\n\`\`\`\n\n`;
+}
+Rule.meta = {
+  usage: '<Rule premises={["A"]} conclusion="B" name="MyRule" />',
+  output: "```math block with \\frac{A}{B} \\text{ (MyRule)}",
+} satisfies ComponentMeta;
+
+export function RuleSet({ title, children: c }: { title?: string; children?: any }) {
+  const body = flatten(c);
+  return title ? `## ${title}\n\n${body}` : body;
+}
+RuleSet.meta = {
+  usage: '<RuleSet title="Rules"><Rule ... /></RuleSet>',
+  output: "Optional heading followed by grouped Rule blocks",
+} satisfies ComponentMeta;


### PR DESCRIPTION
Closes #9

## Summary

- Adds `Rule` — renders an inference rule as a GitHub-native `math` fenced block using `\frac{premises}{conclusion} \text{ (name)}` notation
- Adds `RuleSet` — optional heading + flattened `Rule` children for grouping related rules
- Adds `unicodeToLatex` helper in `helpers.ts` — single-pass conversion of `⟨ ⟩ ⇓ ⇑ σ && ≠ ∈` to LaTeX equivalents
- Both components exported from the barrel (`src/components/index.ts`)

## Test plan

- [x] `unicodeToLatex` — angle brackets, Downarrow, sigma, `&&`, plain text, realistic premise string
- [x] `Rule` — math block structure, name label present/absent, multi-premise `\quad` join, Unicode conversion, exact issue example
- [x] `RuleSet` — no title, with title, multiple rules grouped
- [x] All 92 tests pass (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)