### PR TITLE
feat: root index.ts — import { ... } from "readme" now resolves cleanly

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export * from "./src/index";

--- a/src/cross-repo.test.ts
+++ b/src/cross-repo.test.ts
@@ -20,7 +20,7 @@ describe("cross-repo build", () => {
     await writeFile(
       join(dir, "README.tsx"),
       `/** @jsxImportSource jsx-md */
-import { Heading, Paragraph, Bold } from "readme/src/components";
+import { Heading, Paragraph, Bold } from "readme";
 
 const readme = (
   <>
@@ -41,6 +41,7 @@ console.log(readme);
           paths: {
             "jsx-md/jsx-runtime": [`${REPO_DIR}/src/jsx-runtime.ts`],
             "jsx-md/jsx-dev-runtime": [`${REPO_DIR}/src/jsx-dev-runtime.ts`],
+            "readme": [`${REPO_DIR}/index.ts`],
             "readme/*": [`${REPO_DIR}/*`],
           },
         },
@@ -68,7 +69,7 @@ console.log(readme);
     // Same file but WITHOUT the pragma — should fail to use our runtime
     await writeFile(
       join(dir, "README.tsx"),
-      `import { Heading, Paragraph, Bold } from "readme/src/components";
+      `import { Heading, Paragraph, Bold } from "readme";
 
 const readme = (
   <>
@@ -89,6 +90,7 @@ console.log(readme);
           paths: {
             "jsx-md/jsx-runtime": [`${REPO_DIR}/src/jsx-runtime.ts`],
             "jsx-md/jsx-dev-runtime": [`${REPO_DIR}/src/jsx-dev-runtime.ts`],
+            "readme": [`${REPO_DIR}/index.ts`],
             "readme/*": [`${REPO_DIR}/*`],
           },
         },


### PR DESCRIPTION
Closes #13

## Summary

- Adds `index.ts` at the repo root — a one-liner re-export from `./src/index` — giving consumers a stable public entry point
- Updates both cross-repo tests to import from `"readme"` instead of `"readme/src/components"`, and adds `"readme": ["${REPO_DIR}/index.ts"]` to each test's tsconfig path mapping

## Before / After

```ts
// Before — reaches into src/ internals
import { Heading, Bold } from "readme/src/components";

// After — clean public API
import { Heading, Bold } from "readme";
```

Consumer tsconfig:
```json
"readme": ["path/to/readme/index.ts"],
"readme/*": ["path/to/readme/*"]
```

## Test plan

- [x] Cross-repo test (pragma path) passes with `"readme"` import — markdown rendered correctly
- [x] Cross-repo regression guard still correctly detects raw JSX output without pragma
- [x] All 77 tests pass (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)