### PR TITLE
feat: Anchor, TOC, and slugify for in-page navigation

### DIFF
--- a/src/components.test.tsx
+++ b/src/components.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "bun:test";
 import {
-  Bold, Italic, Code, Link, Image,
+  Bold, Italic, Code, Link, Image, Anchor,
   Heading, Paragraph, CodeBlock, Blockquote, HR, LineBreak,
   List, Item,
   Table, TableHead, TableRow, Cell,
@@ -11,6 +11,7 @@ import {
   Section,
   Alert,
   box, labeledBox, sideBySide,
+  TOC, slugify,
 } from "./components";
 import { escapeHtml } from "./components/helpers";
 
@@ -618,5 +619,90 @@ describe("Chat", () => {
     expect(result).toContain("**bob**");
     expect(result).toContain("> hi");
     expect(result).toContain("> hey");
+  });
+});
+
+// --- slugify helper ---
+
+describe("slugify", () => {
+  test("lowercases text", () => {
+    expect(slugify("Hello World")).toBe("hello-world");
+  });
+
+  test("replaces spaces with hyphens", () => {
+    expect(slugify("getting started")).toBe("getting-started");
+  });
+
+  test("strips non-word characters", () => {
+    expect(slugify("What's new?")).toBe("whats-new");
+  });
+
+  test("preserves existing hyphens", () => {
+    expect(slugify("step-by-step")).toBe("step-by-step");
+  });
+
+  test("handles multiple spaces", () => {
+    expect(slugify("a  b")).toBe("a-b");
+  });
+});
+
+// --- Anchor component ---
+
+describe("Anchor", () => {
+  test("renders in-page link", () => {
+    expect(<Anchor id="installation">Installation</Anchor>).toBe("[Installation](#installation)");
+  });
+
+  test("uses provided id verbatim", () => {
+    expect(<Anchor id="my-section">My Section</Anchor>).toBe("[My Section](#my-section)");
+  });
+});
+
+// --- TOC component ---
+
+describe("TOC", () => {
+  test("renders a single entry", () => {
+    expect(<TOC entries={[{ text: "Installation" }]} />).toBe("- [Installation](#installation)\n\n");
+  });
+
+  test("auto-slugs text when id is omitted", () => {
+    expect(<TOC entries={[{ text: "Getting Started" }]} />).toBe("- [Getting Started](#getting-started)\n\n");
+  });
+
+  test("uses explicit id when provided", () => {
+    expect(<TOC entries={[{ text: "Intro", id: "custom-id" }]} />).toBe("- [Intro](#custom-id)\n\n");
+  });
+
+  test("indents by level relative to minimum", () => {
+    const result = <TOC entries={[
+      { text: "Install", level: 1 },
+      { text: "Usage", level: 2 },
+      { text: "Advanced", level: 3 },
+    ]} />;
+    expect(result).toBe(
+      "- [Install](#install)\n" +
+      "  - [Usage](#usage)\n" +
+      "    - [Advanced](#advanced)\n\n"
+    );
+  });
+
+  test("indentation is relative — level 2 base has no leading indent", () => {
+    const result = <TOC entries={[
+      { text: "Usage", level: 2 },
+      { text: "Advanced", level: 3 },
+    ]} />;
+    expect(result).toBe(
+      "- [Usage](#usage)\n" +
+      "  - [Advanced](#advanced)\n\n"
+    );
+  });
+
+  test("returns empty string for empty entries", () => {
+    expect(<TOC entries={[]} />).toBe("");
+  });
+
+  test("defaults level to 1 when omitted", () => {
+    const result = <TOC entries={[{ text: "A" }, { text: "B" }]} />;
+    expect(result).toBe("- [A](#a)\n- [B](#b)\n\n");
   });
 });

--- a/src/components/helpers.ts
+++ b/src/components/helpers.ts
@@ -14,3 +14,7 @@ export function escapeHtml(s: string): string {
 export function shieldsEncode(s: string): string {
   return encodeURIComponent(s).replaceAll("-", "--").replaceAll("_", "__");
 }
+
+export function slugify(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, "-").replace(/[^\w-]/g, "");
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,7 +11,7 @@
 // README.tsx to auto-generate the component reference table.
 
 export type { ComponentMeta } from "./types";
-export { Bold, Italic, Code, Link, Image } from "./inline";
+export { Bold, Italic, Code, Link, Image, Anchor } from "./inline";
 export { Heading, Paragraph, CodeBlock, Blockquote, HR, LineBreak } from "./block";
 export { List, Item } from "./list";
 export { Table, TableHead, TableRow, Cell } from "./table";
@@ -22,3 +22,6 @@ export { Alert } from "./alert";
 export { Chat, Message } from "./chat";
 export type { BoxStyle } from "./box";
 export { box, labeledBox, sideBySide } from "./box";
+export type { TocEntry } from "./toc";
+export { TOC } from "./toc";
+export { slugify } from "./helpers";

--- a/src/components/inline.tsx
+++ b/src/components/inline.tsx
@@ -27,3 +27,8 @@ export function Image({ src, alt, width }: { src: string; alt: string; width?: n
   return `![${alt}](${src})`;
 }
 Image.meta = { usage: '<Image src="..." alt="..." />', output: "![alt](src) or HTML with width" } satisfies ComponentMeta;
+
+export function Anchor({ id, children: c }: { id: string; children: string }) {
+  return `[${c}](#${id})`;
+}
+Anchor.meta = { usage: '<Anchor id="section">text</Anchor>', output: "[text](#section)" } satisfies ComponentMeta;

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -1,0 +1,23 @@
+import type { ComponentMeta } from "./types";
+import { slugify } from "./helpers";
+
+export interface TocEntry {
+  text: string;
+  id?: string;
+  level?: number;
+}
+
+export function TOC({ entries }: { entries: TocEntry[] }) {
+  if (entries.length === 0) return "";
+  const minLevel = Math.min(...entries.map((e) => e.level ?? 1));
+  const lines = entries.map((e) => {
+    const indent = "  ".repeat((e.level ?? 1) - minLevel);
+    const id = e.id ?? slugify(e.text);
+    return `${indent}- [${e.text}](#${id})`;
+  });
+  return lines.join("\n") + "\n\n";
+}
+TOC.meta = {
+  usage: '<TOC entries={[{ text: "Usage", level: 2 }]} />',
+  output: "Nested markdown list of in-page links",
+} satisfies ComponentMeta;


### PR DESCRIPTION
Closes #3

## Summary

- **`Anchor`** — inline in-page link: `<Anchor id="section">text</Anchor>` → `[text](#section)`
- **`TOC`** — data-driven nested list of anchor links; auto-slugs `id` from `text` when not provided; indentation is relative to the minimum level in the entry list
- **`slugify`** — GitHub-compatible heading slug helper (lowercase, spaces→hyphens, strip non-word chars); exported from the barrel for consumer use
- **Callout** — already covered by the existing `Alert` component; no work needed

## Usage

```tsx
<TOC entries={[
  { text: "Installation" },
  { text: "Usage", level: 2 },
  { text: "Advanced", level: 2 },
  { text: "Contributing" },
]} />
```

```markdown
- [Installation](#installation)
  - [Usage](#usage)
  - [Advanced](#advanced)
- [Contributing](#contributing)
```

## Test plan

- [x] `slugify` — lowercase, spaces→hyphens, strips special chars, preserves hyphens, handles multiple spaces
- [x] `Anchor` — renders `[text](#id)`, uses id verbatim
- [x] `TOC` — single entry, auto-slug, explicit id, level indentation, relative base level, empty entries, default level
- [x] All 91 tests pass (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)