### PR TITLE
refactor: deduplicate flatten — jsx-runtime imports from helpers

### DIFF
--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -3,6 +3,8 @@
 // Bun calls jsx() / jsxs() for every <Tag> in a .tsx file.
 // Instead of building a DOM tree, we return plain strings.
 
+import { flatten } from "./components/helpers";
+
 export function jsx(
   tag: string | Function,
   props: Record<string, any>,
@@ -14,12 +16,6 @@ export function jsx(
 }
 
 export const jsxs = jsx;
-
-function flatten(c: any): string {
-  if (c == null) return "";
-  if (Array.isArray(c)) return c.map(flatten).join("");
-  return String(c);
-}
 
 export function Fragment({ children }: { children?: any }): string {
   return flatten(children);


### PR DESCRIPTION
Closes #4

## Summary

- Removes the private `flatten` definition in `src/jsx-runtime.ts`
- Adds `import { flatten } from "./components/helpers"` — the exported, identical implementation already used by all component modules
- `Fragment` is the only caller in `jsx-runtime.ts`; no behaviour change

## Test plan

- [x] All 77 tests pass (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)