### PR TITLE
feat: add sources/outputs to build task for incremental skipping

### DIFF
--- a/.mise/tasks/build
+++ b/.mise/tasks/build
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Generate README.md from README.tsx"
+#MISE sources=["README.tsx", "src/**/*.ts", "src/**/*.tsx"]
+#MISE outputs=["README.md"]
 #USAGE flag "--check" help="Check if README.md is up to date (exit 1 if stale)"
 set -e
 


### PR DESCRIPTION
Closes #15

## Summary

Adds two `#MISE` frontmatter directives to `.mise/tasks/build`:

```bash
#MISE sources=["README.tsx", "src/**/*.ts", "src/**/*.tsx"]
#MISE outputs=["README.md"]
```

Mise will now skip the build entirely when `README.md` is newer than all source files — no unnecessary regeneration on repeated `mise run build` calls.

## Scope note

Covers the self-repo case (running `mise run build` inside the `readme` repo). Cross-repo use via `$CALLER_PWD` is unaffected — sources/outputs don't apply there and the task behaviour is unchanged.

## Test plan

- [x] All 77 tests pass (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)