### PR TITLE
[ready for senior review] feat: TerminalImage component and terminal SVG generation library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@v2
 
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Run tests
         run: mise run test
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+CLAUDE.md
+/memory/

--- a/.mise/tasks/terminal-assets
+++ b/.mise/tasks/terminal-assets
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#MISE description="Generate terminal screenshot SVG assets from a definitions file"
+#USAGE flag "--out-dir <dir>" help="Output directory for SVG assets (default: docs/assets/terminal)" default="docs/assets/terminal"
+#USAGE arg "<definitions>" help="Path to a JS/TS file that exports an array of { content, opts? } entries" required=true
+set -e
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${usage_out_dir:-docs/assets/terminal}"
+
+TSCONFIG=$(mktemp)
+cat > "$TSCONFIG" <<CONF
+{
+  "compilerOptions": {
+    "paths": {
+      "readme": ["$REPO_DIR/src/index.ts"],
+      "readme/*": ["$REPO_DIR/*"]
+    }
+  }
+}
+CONF
+trap 'rm -f "$TSCONFIG"' EXIT
+
+bun run --tsconfig-override "$TSCONFIG" - <<SCRIPT
+import entries from "$1";
+import { writeTerminalAsset, terminalAssetPath } from "$REPO_DIR/src/lib/terminal.ts";
+import { mkdir } from "fs/promises";
+await mkdir("$OUT_DIR", { recursive: true });
+for (const { content, opts } of entries) {
+  const path = await writeTerminalAsset(content, { ...opts, outDir: "$OUT_DIR" });
+  console.log("Generated", path);
+}
+SCRIPT

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ readme build              # README.tsx → README.md
 readme build --check      # Exit 1 if README.md is stale (for CI)
 ```
 
-## Components (35)
+## Components (39)
 
 Auto-generated from `src/components/` exports. Each component carries a `.meta` property describing its usage.
 
@@ -93,9 +93,13 @@ Auto-generated from `src/components/` exports. Each component carries a `.meta` 
 | `<Table>...</Table>` | GFM table (Prettier-compatible padding) |
 | `<TableHead><Cell>...</Cell></TableHead>` | Header row + separator |
 | `<TableRow><Cell>...</Cell></TableRow>` | Table data row |
+| `<TerminalImage src="docs/assets/terminal/abc123.svg" alt="demo" />` | ![demo](docs/assets/terminal/abc123.svg) |
 | `box(lines, { style, padding })` | ASCII or Unicode box around text (string[]) |
+| `generateTerminalSvg` | ⚠️ undocumented |
 | `labeledBox(title, body, status?)` | Box with title, body, and optional status |
 | `sideBySide(columns, gap)` | Place line arrays side by side |
+| `terminalAssetPath` | ⚠️ undocumented |
+| `writeTerminalAsset` | ⚠️ undocumented |
 
 ## Why JSX?
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,42 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "ansi-to-svg": "^1.4.3",
+      },
+    },
+  },
+  "packages": {
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
+
+    "ansi-regex": ["ansi-regex@3.0.1", "", {}, "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="],
+
+    "ansi-to": ["ansi-to@1.5.1", "", { "dependencies": { "deepmerge": "^2.1.0", "itermcolors-to-hex": "^1.0.1", "parse-ansi": "^1.0.3" } }, "sha512-fsfvV6jp4lUKB9+13WLWpd7h0d5oU7oSUITyBmNXWQwuIaGTxpgFe5GUUVzajj0Wb2oHn7mHkizoPNXReitinA=="],
+
+    "ansi-to-svg": ["ansi-to-svg@1.4.3", "", { "dependencies": { "ansi-to": "^1.3.0", "he": "^1.1.1" } }, "sha512-kFF+NtyYtzlW4fUaXbavTgwo0akCjYz7DjyzVpL09BWwgWwhPZSilAJW2zMXsV7V/ly61P0bnWF6l0brmdYebQ=="],
+
+    "array-uniq": ["array-uniq@1.0.3", "", {}, "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "deepmerge": ["deepmerge@2.2.1", "", {}, "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="],
+
+    "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
+
+    "itermcolors-to-hex": ["itermcolors-to-hex@1.0.1", "", { "dependencies": { "plist": "^3.0.1", "rgb-hex": "^2.1.0" } }, "sha512-DGcY7JCmmPL9oLQKUW+vOcnlnwhUmcK2upZVAg5htz0sK3/a0sF4n/X01vC5N+vzRxI9tWR92RdW0aDpu/urDA=="],
+
+    "parse-ansi": ["parse-ansi@1.0.3", "", { "dependencies": { "ansi-regex": "^3.0.0", "array-uniq": "^1.0.3", "deepmerge": "^2.1.0", "strip-ansi": "^4.0.0", "super-split": "^1.1.0" } }, "sha512-xrvGsb43DHlcwmVuurG44PYJXUwd/obLocHbSSVofi+QX6lPxnShVYmRU+GZbKNuvMYbkbWU2TGgmLGl3F1dEw=="],
+
+    "plist": ["plist@3.1.1", "", { "dependencies": { "@xmldom/xmldom": "^0.9.10", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA=="],
+
+    "rgb-hex": ["rgb-hex@2.1.0", "", {}, "sha512-1hDa60MqECZiEGsa9TtcOE9VbV6fhZSMQARy7U+a2HkhIJyoEBhcG4v/qYAJYzV3Bbj+j52sBoAIKKF5EPuQZw=="],
+
+    "strip-ansi": ["strip-ansi@4.0.0", "", { "dependencies": { "ansi-regex": "^3.0.0" } }, "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow=="],
+
+    "super-split": ["super-split@1.1.0", "", {}, "sha512-I4bA5mgcb6Fw5UJ+EkpzqXfiuvVGS/7MuND+oBxNFmxu3ugLNrdIatzBLfhFRMVMLxgSsRy+TjIktgkF9RFSNQ=="],
+
+    "xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "ansi-to-svg": "^1.4.3"
+  }
+}

--- a/src/components.test.tsx
+++ b/src/components.test.tsx
@@ -11,6 +11,7 @@ import {
   Section,
   Alert,
   box, labeledBox, sideBySide,
+  TerminalImage,
 } from "./components";
 import { escapeHtml } from "./components/helpers";
 
@@ -618,5 +619,21 @@ describe("Chat", () => {
     expect(result).toContain("**bob**");
     expect(result).toContain("> hi");
     expect(result).toContain("> hey");
+  });
+});
+
+// --- TerminalImage ---
+
+describe("TerminalImage", () => {
+  test("renders markdown image", () => {
+    expect(
+      <TerminalImage src="docs/assets/terminal/abc123.svg" alt="demo" />
+    ).toBe("![demo](docs/assets/terminal/abc123.svg)");
+  });
+
+  test("renders HTML img when width provided", () => {
+    expect(
+      <TerminalImage src="docs/assets/terminal/abc123.svg" alt="demo" width={600} />
+    ).toBe('<img src="docs/assets/terminal/abc123.svg" alt="demo" width="600" />');
   });
 });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,5 +20,6 @@ export { Raw, HtmlLink, Sub, HtmlTable, HtmlTr, HtmlTd } from "./html";
 export { Badge, Badges } from "./badges";
 export { Alert } from "./alert";
 export { Chat, Message } from "./chat";
+export { TerminalImage } from "./terminal";
 export type { BoxStyle } from "./box";
 export { box, labeledBox, sideBySide } from "./box";

--- a/src/components/terminal.tsx
+++ b/src/components/terminal.tsx
@@ -1,0 +1,12 @@
+import type { ComponentMeta } from "./types";
+
+export function TerminalImage({ src, alt, width }: { src: string; alt: string; width?: number }) {
+  if (width) {
+    return `<img src="${src}" alt="${alt}" width="${width}" />`;
+  }
+  return `![${alt}](${src})`;
+}
+TerminalImage.meta = {
+  usage: '<TerminalImage src="docs/assets/terminal/abc123.svg" alt="demo" />',
+  output: "![demo](docs/assets/terminal/abc123.svg)",
+} satisfies ComponentMeta;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,5 @@
 //   import { Heading, Paragraph, Bold, Code, Link } from "readme";
 
 export * from "./components/index";
+export type { TerminalOptions } from "./lib/terminal";
+export { terminalAssetPath, generateTerminalSvg, writeTerminalAsset } from "./lib/terminal";

--- a/src/lib/terminal.test.ts
+++ b/src/lib/terminal.test.ts
@@ -1,0 +1,83 @@
+import { expect, test, describe } from "bun:test";
+import { mkdtemp, rm } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { terminalAssetPath, generateTerminalSvg, writeTerminalAsset } from "./terminal";
+
+describe("terminalAssetPath", () => {
+  test("returns path under default outDir", () => {
+    const path = terminalAssetPath("hello");
+    expect(path).toStartWith("docs/assets/terminal/");
+    expect(path).toEndWith(".svg");
+  });
+
+  test("is deterministic for same content", () => {
+    expect(terminalAssetPath("hello")).toBe(terminalAssetPath("hello"));
+  });
+
+  test("differs for different content", () => {
+    expect(terminalAssetPath("hello")).not.toBe(terminalAssetPath("world"));
+  });
+
+  test("respects custom outDir", () => {
+    expect(terminalAssetPath("hello", "out/svgs")).toStartWith("out/svgs/");
+  });
+
+  test("hash is 8 hex chars", () => {
+    const path = terminalAssetPath("hello");
+    const filename = path.split("/").at(-1)!.replace(".svg", "");
+    expect(filename).toMatch(/^[0-9a-f]{8}$/);
+  });
+});
+
+describe("generateTerminalSvg", () => {
+  test("returns an SVG string", async () => {
+    const svg = await generateTerminalSvg("$ echo hello\nhello");
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("</svg>");
+  });
+
+  test("includes the terminal content", async () => {
+    const svg = await generateTerminalSvg("hello world");
+    expect(svg).toContain("hello");
+  });
+
+  test("accepts dark theme", async () => {
+    const svg = await generateTerminalSvg("hello", { theme: "dark" });
+    expect(svg).toContain("<svg");
+  });
+
+  test("accepts light theme", async () => {
+    const svg = await generateTerminalSvg("hello", { theme: "light" });
+    expect(svg).toContain("<svg");
+  });
+});
+
+describe("writeTerminalAsset", () => {
+  test("writes SVG file and returns path", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "terminal-test-"));
+    try {
+      const path = await writeTerminalAsset("$ echo hi", { outDir: dir });
+      expect(path).toStartWith(dir);
+      expect(path).toEndWith(".svg");
+      const file = Bun.file(path);
+      expect(await file.exists()).toBe(true);
+      const content = await file.text();
+      expect(content).toContain("<svg");
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+
+  test("creates output directory if it does not exist", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "terminal-test-"));
+    try {
+      const nested = join(dir, "deep", "nested");
+      const path = await writeTerminalAsset("hello", { outDir: nested });
+      const file = Bun.file(path);
+      expect(await file.exists()).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+});

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -1,0 +1,32 @@
+import ansiToSvg from "ansi-to-svg";
+import { createHash } from "crypto";
+import { mkdir, writeFile } from "fs/promises";
+import { dirname } from "path";
+
+export interface TerminalOptions {
+  title?: string;
+  theme?: "dark" | "light";
+  width?: number;
+  padding?: number;
+  outDir?: string;
+}
+
+export function terminalAssetPath(content: string, outDir = "docs/assets/terminal"): string {
+  const hash = createHash("sha1").update(content).digest("hex").slice(0, 8);
+  return `${outDir}/${hash}.svg`;
+}
+
+export async function generateTerminalSvg(content: string, opts: TerminalOptions = {}): Promise<string> {
+  return ansiToSvg(content, {
+    colors: opts.theme === "light" ? "solarized" : "github",
+    ...(opts.width ? { width: opts.width } : {}),
+    ...(opts.padding ? { paddingTop: opts.padding, paddingBottom: opts.padding } : {}),
+  });
+}
+
+export async function writeTerminalAsset(content: string, opts: TerminalOptions = {}): Promise<string> {
+  const path = terminalAssetPath(content, opts.outDir);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, await generateTerminalSvg(content, opts));
+  return path;
+}


### PR DESCRIPTION
Closes #24

## Summary

- **`TerminalImage`** component — sync, renders `![alt](src)` or `<img src=... width=...>` from a pre-generated asset path; exported from the barrel
- **`src/lib/terminal.ts`** — async build-time helpers:
  - `generateTerminalSvg(content, opts)` — converts ANSI/plain text to SVG via `ansi-to-svg`
  - `terminalAssetPath(content, outDir?)` — deterministic SHA-1 hash filename (`docs/assets/terminal/{8hex}.svg`)
  - `writeTerminalAsset(content, opts?)` — generates SVG and writes to disk, creating dirs as needed
- **`.mise/tasks/terminal-assets`** — mise task consumers run before `build` to generate assets from a definitions file
- **`ansi-to-svg@1.4.3`** added as the only new dependency (no external CLI required)

## Architecture note

The JSX render pipeline stays synchronous. Asset generation is a separate pre-step (`mise run terminal-assets <defs.ts>`), keeping the component library clean. `TerminalImage` accepts a pre-generated `src` path — consumers call `writeTerminalAsset` in their build scripts and pass the returned path to the component.

## Test plan

- [x] `terminalAssetPath` — deterministic, differs per content, custom outDir, 8-char hex hash
- [x] `generateTerminalSvg` — returns valid SVG, includes content, dark/light theme
- [x] `writeTerminalAsset` — writes SVG file, creates nested dirs
- [x] `TerminalImage` — markdown image, HTML img with width
- [x] All 90 tests pass (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)