### PR TITLE
feat: composite GitHub Action for README build/check (milestone 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,25 @@ readme build              # README.tsx → README.md
 readme build --check      # Exit 1 if README.md is stale (for CI)
 ```
 
+## GitHub Action
+
+Use the composite action to keep generated READMEs honest in CI:
+
+```yaml
+- uses: KnickKnackLabs/readme@v0.3.0
+  with:
+    check: true
+```
+
+For READMEs outside the workspace root, set `working-directory` to the directory containing `README.tsx`:
+
+```yaml
+- uses: KnickKnackLabs/readme@v0.3.0
+  with:
+    check: true
+    working-directory: docs
+```
+
 ## Components (35)
 
 Auto-generated from `src/components/` exports. Each component carries a `.meta` property describing its usage.

--- a/README.tsx
+++ b/README.tsx
@@ -90,6 +90,26 @@ console.log(readme);`}</CodeBlock>
 readme build --check      # Exit 1 if README.md is stale (for CI)`}</CodeBlock>
     </Section>
 
+    <Section title="GitHub Action">
+      <Paragraph>
+        Use the composite action to keep generated READMEs honest in CI:
+      </Paragraph>
+
+      <CodeBlock lang="yaml">{`- uses: KnickKnackLabs/readme@v0.3.0
+  with:
+    check: true`}</CodeBlock>
+
+      <Paragraph>
+        For READMEs outside the workspace root, set <Code>working-directory</Code>
+        {" to the directory containing "}<Code>README.tsx</Code>:
+      </Paragraph>
+
+      <CodeBlock lang="yaml">{`- uses: KnickKnackLabs/readme@v0.3.0
+  with:
+    check: true
+    working-directory: docs`}</CodeBlock>
+    </Section>
+
     <Section title={`Components (${componentRows.length})`}>
       <Paragraph>
         {"Auto-generated from "}

--- a/action.yml
+++ b/action.yml
@@ -22,11 +22,30 @@ runs:
     - name: Build / check README
       shell: bash
       env:
-        README_CALLER_PWD: ${{ inputs.working-directory || github.workspace }}
+        ACTION_PATH: ${{ github.action_path }}
+        INPUT_CHECK: ${{ inputs.check }}
+        INPUT_WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        WORKSPACE: ${{ github.workspace }}
       run: |
-        cd "${{ github.action_path }}"
-        if [[ "${{ inputs.check }}" == "true" ]]; then
-          mise run build -- --check
+        set -euo pipefail
+
+        target="$WORKSPACE"
+        if [[ -n "$INPUT_WORKING_DIRECTORY" ]]; then
+          if [[ "$INPUT_WORKING_DIRECTORY" = /* ]]; then
+            target="$INPUT_WORKING_DIRECTORY"
+          else
+            target="$WORKSPACE/$INPUT_WORKING_DIRECTORY"
+          fi
+        fi
+
+        if [[ ! -d "$target" ]]; then
+          echo "readme action: working-directory does not exist: $target" >&2
+          exit 1
+        fi
+        target="$(cd "$target" && pwd)"
+
+        if [[ "$INPUT_CHECK" == "true" ]]; then
+          README_CALLER_PWD="$target" mise -C "$ACTION_PATH" run build --check
         else
-          mise run build
+          README_CALLER_PWD="$target" mise -C "$ACTION_PATH" run build
         fi

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,32 @@
+name: README check
+description: Build or verify README.md from README.tsx using the readme package.
+
+inputs:
+  check:
+    description: If true, exit 1 when README.md is out of date instead of regenerating it.
+    required: false
+    default: 'false'
+  working-directory:
+    description: Directory containing README.tsx. Defaults to the caller's workspace root.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install mise
+      uses: jdx/mise-action@v2
+      with:
+        working_directory: ${{ github.action_path }}
+
+    - name: Build / check README
+      shell: bash
+      env:
+        README_CALLER_PWD: ${{ inputs.working-directory || github.workspace }}
+      run: |
+        cd "${{ github.action_path }}"
+        if [[ "${{ inputs.check }}" == "true" ]]; then
+          mise run build -- --check
+        else
+          mise run build
+        fi


### PR DESCRIPTION
Closes #25

## Summary

Adds `action.yml` at the repo root — a composite action that downstream repos can adopt with a single step.

## Usage

**Check (CI validation):**
```yaml
- uses: KnickKnackLabs/readme@v1
  with:
    check: true
```

**Regenerate:**
```yaml
- uses: KnickKnackLabs/readme@v1
```

**Custom directory:**
```yaml
- uses: KnickKnackLabs/readme@v1
  with:
    check: true
    working-directory: path/to/subdir
```

## How it works

1. `jdx/mise-action@v2` installs mise and runs `mise install` inside the readme package directory (picking up bun from `mise.toml`)
2. `README_CALLER_PWD` is set to the caller's workspace (or `working-directory` input), directing the build task at the right repo — relies on #23
3. `mise run build -- --check` or `mise run build` is run from the readme package root

## Milestone 1 checklist

- [x] Composite action shape (`uses: KnickKnackLabs/readme@v1`)
- [x] Runs `readme build --check`
- [x] Caller cwd handled correctly via `README_CALLER_PWD` (#23)
- [ ] README section showing downstream usage — follow-up
- [ ] Tag `v1` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)