### PR TITLE
feat(lib): shared mise task-parsing library (src/lib/mise.ts) (#18)

### DIFF
--- a/src/lib/mise.test.ts
+++ b/src/lib/mise.test.ts
@@ -1,0 +1,138 @@
+import { expect, test, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, mkdir, writeFile, rm } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import { parseTasks, countBatsTests } from "./mise";
+
+describe("parseTasks", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "readme-mise-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const task = async (rel: string, body: string) => {
+    const full = join(dir, rel);
+    await mkdir(join(full, ".."), { recursive: true });
+    await writeFile(full, body);
+  };
+
+  test("parses description, a boolean flag, and a valued flag with short/required/default", async () => {
+    await task(
+      "build",
+      `#!/usr/bin/env bash
+#MISE description="Build the thing"
+#USAGE flag "--check" help="Exit 1 if stale"
+#USAGE flag "-o --out-dir <dir>" help="Where to write" default="dist" required=#true
+set -e
+`,
+    );
+
+    const [cmd] = parseTasks(dir);
+    expect(cmd.name).toBe("build");
+    expect(cmd.description).toBe("Build the thing");
+
+    const check = cmd.flags.find((f) => f.name === "--check")!;
+    expect(check.isBoolean).toBe(true);
+    expect(check.help).toBe("Exit 1 if stale");
+    expect(check.valueName).toBeUndefined();
+
+    const out = cmd.flags.find((f) => f.name === "--out-dir")!;
+    expect(out.isBoolean).toBe(false);
+    expect(out.shortFlag).toBe("-o");
+    expect(out.valueName).toBe("dir");
+    expect(out.default).toBe("dist");
+    expect(out.required).toBe(true);
+  });
+
+  test("distinguishes required <arg> from optional [arg]", async () => {
+    await task(
+      "run",
+      `#MISE description="Run it"
+#USAGE arg "<input>" help="Source file"
+#USAGE arg "[output]" help="Destination"
+`,
+    );
+
+    const [cmd] = parseTasks(dir);
+    expect(cmd.args).toEqual([
+      { name: "input", help: "Source file", optional: false },
+      { name: "output", help: "Destination", optional: true },
+    ]);
+  });
+
+  test("walks nested dirs into ':'-joined names", async () => {
+    await task("pre-commit/install", `#MISE description="Install hook"\n`);
+    await task("pre-commit/remove", `#MISE description="Remove hook"\n`);
+
+    const names = parseTasks(dir).map((c) => c.name);
+    expect(names).toContain("pre-commit:install");
+    expect(names).toContain("pre-commit:remove");
+  });
+
+  test("excludes hidden tasks and dot/underscore-prefixed entries", async () => {
+    await task("visible", `#MISE description="Shown"\n`);
+    await task("secret", `#MISE description="Nope"\n#MISE hide=true\n`);
+    await task("_helper", `#MISE description="Helper"\n`);
+    await task(".dotfile", `#MISE description="Dotfile"\n`);
+
+    const names = parseTasks(dir).map((c) => c.name);
+    expect(names).toEqual(["visible"]);
+  });
+
+  test("returns results sorted by name", async () => {
+    await task("zebra", `#MISE description="z"\n`);
+    await task("apple", `#MISE description="a"\n`);
+    await task("mango", `#MISE description="m"\n`);
+
+    expect(parseTasks(dir).map((c) => c.name)).toEqual(["apple", "mango", "zebra"]);
+  });
+
+  test("returns [] for a missing directory", () => {
+    expect(parseTasks(join(dir, "does-not-exist"))).toEqual([]);
+  });
+
+  test("parses this repo's own .mise/tasks (dogfood)", () => {
+    const tasks = parseTasks(join(import.meta.dir, "../../.mise/tasks"));
+    const names = tasks.map((t) => t.name);
+    expect(names).toContain("build");
+    expect(names).toContain("pre-commit:install");
+
+    const build = tasks.find((t) => t.name === "build")!;
+    expect(build.flags.some((f) => f.name === "--check")).toBe(true);
+  });
+});
+
+describe("countBatsTests", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "readme-bats-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("counts @test across multiple .bats files and lists only .bats", async () => {
+    await writeFile(
+      join(dir, "a.bats"),
+      `@test "one" {\n  true\n}\n@test "two" {\n  true\n}\n`,
+    );
+    await writeFile(join(dir, "b.bats"), `@test "three" {\n  true\n}\n`);
+    await writeFile(join(dir, "helpers.bash"), `@test "not counted" {}\n`);
+
+    const { count, files } = countBatsTests(dir);
+    expect(count).toBe(3);
+    expect(files.sort()).toEqual(["a.bats", "b.bats"]);
+  });
+
+  test("returns zero for a missing directory", () => {
+    expect(countBatsTests(join(dir, "nope"))).toEqual({ count: 0, files: [] });
+  });
+});

--- a/src/lib/mise.ts
+++ b/src/lib/mise.ts
@@ -1,0 +1,172 @@
+// Shared parsing helpers for mise file-tasks.
+//
+// mise file-tasks carry metadata in `#MISE` and `#USAGE` comment headers (the
+// jdx/usage spec). README.tsx files across repos kept reimplementing the same
+// parser to auto-generate a command/flags table, plus a `@test` counter for a
+// "tests passing" badge. This consolidates both.
+//
+// mise-specific, so it lives in src/lib and is deliberately NOT re-exported from
+// the main "readme" barrel — codebases that aren't mise-based don't need it.
+//
+//   import { parseTasks, countBatsTests } from "readme/src/lib/mise";
+//
+//   const tasks = parseTasks(".mise/tasks");          // MiseCommand[]
+//   const { count, files } = countBatsTests("test");  // { count, files }
+
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join } from "path";
+
+export interface MiseFlag {
+  /** Long form, e.g. "--check". */
+  name: string;
+  /** Short form if declared, e.g. "-c". */
+  shortFlag?: string;
+  /** Value placeholder for flags that take an argument, e.g. "dir" for `--out-dir <dir>`. */
+  valueName?: string;
+  help: string;
+  required?: boolean;
+  default?: string;
+  /** True when the flag takes no value (`valueName` is absent). */
+  isBoolean: boolean;
+}
+
+export interface MiseArg {
+  name: string;
+  help: string;
+  optional: boolean;
+}
+
+export interface MiseCommand {
+  /** Nested directories are joined with ":", e.g. "pre-commit:install". */
+  name: string;
+  description: string;
+  flags: MiseFlag[];
+  args: MiseArg[];
+  hidden: boolean;
+}
+
+export interface BatsTestCount {
+  count: number;
+  files: string[];
+}
+
+type UsageAttrs = Record<string, string | boolean>;
+
+// Parse the trailing attributes of a #USAGE line, order-independently:
+//   help="..."   default="..."   required=#true
+function parseUsageAttrs(rest: string): UsageAttrs {
+  const attrs: UsageAttrs = {};
+  const attrRe = /(\w[\w-]*)=(?:"([^"]*)"|#(true|false)|([^\s]+))/g;
+  for (const match of rest.matchAll(attrRe)) {
+    const [, key, quoted, bool, bare] = match;
+    if (bool) {
+      attrs[key] = bool === "true";
+    } else {
+      attrs[key] = quoted ?? bare ?? "";
+    }
+  }
+  return attrs;
+}
+
+function stringAttr(attrs: UsageAttrs, key: string): string | undefined {
+  const value = attrs[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function parseTaskFile(filepath: string, name: string): MiseCommand {
+  const lines = readFileSync(filepath, "utf-8").split("\n");
+
+  const description =
+    lines.find((l) => l.startsWith("#MISE description="))
+      ?.match(/#MISE description="(.+)"/)?.[1] ?? "";
+
+  const hidden = lines.some((l) => l.includes("#MISE hide=true"));
+
+  const flags: MiseFlag[] = [];
+  const args: MiseArg[] = [];
+
+  for (const line of lines) {
+    const flagMatch = line.match(
+      /#USAGE flag "(-[\w-]+ )?--(\w[\w-]*)(?:\s+<([\w-]+)>)?"(.*)$/,
+    );
+    if (flagMatch) {
+      const shortFlag = flagMatch[1]?.trim();
+      const flagName = flagMatch[2].replace(/_/g, "-");
+      const valueName = flagMatch[3];
+      const attrs = parseUsageAttrs(flagMatch[4] || "");
+      const required = attrs.required === true;
+      flags.push({
+        name: `--${flagName}`,
+        shortFlag,
+        valueName,
+        help: stringAttr(attrs, "help") ?? "",
+        required: required || undefined,
+        default: stringAttr(attrs, "default"),
+        isBoolean: !valueName,
+      });
+      continue;
+    }
+
+    const argMatch = line.match(/#USAGE arg "([<\[])([\w-]+)([>\]])"(.*)$/);
+    if (argMatch) {
+      const attrs = parseUsageAttrs(argMatch[4] || "");
+      args.push({
+        name: argMatch[2],
+        help: stringAttr(attrs, "help") ?? "",
+        optional: argMatch[1] === "[",
+      });
+    }
+  }
+
+  return { name, description, flags, args, hidden };
+}
+
+// Recursively collect commands. Nested directories become a ":"-joined prefix
+// (matching mise's own task naming, e.g. pre-commit/install → pre-commit:install).
+function walkTasks(dir: string, prefix: string): MiseCommand[] {
+  const results: MiseCommand[] = [];
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".") || entry.name.startsWith("_")) continue;
+    const taskName = prefix ? `${prefix}:${entry.name}` : entry.name;
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      results.push(...walkTasks(fullPath, taskName));
+    } else {
+      results.push(parseTaskFile(fullPath, taskName));
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Parse every mise file-task under `taskDir` (e.g. ".mise/tasks").
+ * Walks nested directories, skips dotfiles / underscore-prefixed helpers and
+ * hidden tasks (`#MISE hide=true`), and returns commands sorted by name.
+ * Returns `[]` if the directory does not exist.
+ */
+export function parseTasks(taskDir: string): MiseCommand[] {
+  if (!existsSync(taskDir)) return [];
+  return walkTasks(taskDir, "")
+    .filter((command) => !command.hidden)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Count `@test` declarations across the `.bats` files in `testDir`.
+ * Returns the total `count` and the list of `.bats` `files` found.
+ * Returns `{ count: 0, files: [] }` if the directory does not exist.
+ */
+export function countBatsTests(testDir: string): BatsTestCount {
+  if (!existsSync(testDir)) return { count: 0, files: [] };
+
+  const files = readdirSync(testDir).filter((f) => f.endsWith(".bats"));
+  const count = files.reduce((total, file) => {
+    const src = readFileSync(join(testDir, file), "utf-8");
+    return total + (src.match(/@test "/g)?.length ?? 0);
+  }, 0);
+
+  return { count, files };
+}


### PR DESCRIPTION
Closes #18.

## Summary
Adds `src/lib/mise.ts` — a shared parser for mise file-task headers — so README.tsx files across the org stop reimplementing the same logic (the issue counts 5+ copies).

```ts
import { parseTasks, countBatsTests } from "readme/src/lib/mise";

const tasks = parseTasks(".mise/tasks");          // MiseCommand[]
const { count, files } = countBatsTests("test");  // { count, files }
```

- **`parseTasks(taskDir)`** — recursively walks task dirs (nested `pre-commit/install` → `pre-commit:install`), parses `#MISE description=` and `#USAGE flag|arg` headers (short forms, value placeholders, `required`/`default`, boolean detection, required `<arg>` vs optional `[arg]`), skips hidden (`#MISE hide=true`) and dot/underscore entries, returns sorted `MiseCommand[]`. Missing dir → `[]`.
- **`countBatsTests(testDir)`** — `{ count, files }` of `@test "` across `.bats` files. Missing dir → `{ count: 0, files: [] }`.

## Consolidated from prior art
- **`chat/readme/mise.ts`** — its order-independent `parseUsageAttrs` and rich `MiseCommand` type (the most evolved version).
- **`secrets/README.tsx`** — its recursive `walkTasks` (chat's version dropped nested dirs).
- `farts` added nothing beyond these.

## Scope
Library + tests only, kept **out of the main `readme` barrel** (mise-specific; deep-import only, so non-mise consumers don't pull it in). Migrating the consumer repos (`chat`, `secrets`, `farts`, `rudi`, `shiv`, `pipes`) to import this is per-repo follow-up.

## Verification
- New suite `src/lib/mise.test.ts`: **9 tests** (flags/args/nested/hidden/sorting/missing-dir + a dogfood assertion against this repo's own `.mise/tasks`).
- `mise run test`: **86 bun + 26 bats** pass.
- `mise run build -- --check`: README unaffected, exits 0.
- Smoke check parses this repo's tasks: `build` (`--check`), `pre-commit:install` (`--build`/`--check`), `pre-commit:remove`, `test`; 26 bats counted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)