### PR TITLE
feat(build): support --file/--output for non-default TSX sources (#38)

### DIFF
--- a/.mise/tasks/build
+++ b/.mise/tasks/build
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Generate README.md from README.tsx"
-#USAGE flag "--check" help="Check if the output is up to date (exit 1 if stale)"
-#USAGE flag "--file <file>" help="TSX source to build (default: README.tsx in the target dir)"
-#USAGE flag "--output <output>" help="Markdown output path (default: source with .tsx->.md)"
+#USAGE flag "--check" help="Check if the output is up to date (exit 1 if stale)" default=#false
+#USAGE flag "--file <file>" help="TSX source to build (default: README.tsx in the target dir)" default=""
+#USAGE flag "--output <output>" help="Markdown output path (default: source with .tsx->.md)" default=""
 set -e
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/.mise/tasks/build
+++ b/.mise/tasks/build
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Generate README.md from README.tsx"
-#USAGE flag "--check" help="Check if README.md is up to date (exit 1 if stale)"
+#USAGE flag "--check" help="Check if the output is up to date (exit 1 if stale)"
+#USAGE flag "--file <file>" help="TSX source to build (default: README.tsx in the target dir)"
+#USAGE flag "--output <output>" help="Markdown output path (default: source with .tsx->.md)"
 set -e
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -14,6 +16,35 @@ if [[ -z "${README_CALLER_PWD:-}" ]]; then
 fi
 
 TARGET_DIR="$README_CALLER_PWD"
+
+# Resolve the source (input) and output paths. Defaults preserve the
+# directory-based contract (README.tsx -> README.md); --file targets a specific
+# TSX source and --output overrides the destination. Relative paths resolve
+# against the caller's directory; absolute paths are honored as-is.
+resolve_path() {
+  case "$1" in
+    /*) printf '%s\n' "$1" ;;
+    *) printf '%s/%s\n' "$TARGET_DIR" "$1" ;;
+  esac
+}
+
+if [[ -n "${usage_file:-}" ]]; then
+  SRC_FILE="$(resolve_path "$usage_file")"
+else
+  SRC_FILE="$TARGET_DIR/README.tsx"
+fi
+
+if [[ -n "${usage_output:-}" ]]; then
+  OUT_FILE="$(resolve_path "$usage_output")"
+elif [[ -n "${usage_file:-}" ]]; then
+  if [[ "$SRC_FILE" != *.tsx ]]; then
+    echo "Error: --file '$usage_file' does not end in .tsx; pass --output explicitly." >&2
+    exit 1
+  fi
+  OUT_FILE="${SRC_FILE%.tsx}.md"
+else
+  OUT_FILE="$TARGET_DIR/README.md"
+fi
 
 # Bun's --tsconfig-override is broken for jsxImportSource (oven-sh/bun#22023),
 # but it does work for paths. So we split the responsibility:
@@ -34,32 +65,33 @@ cat > "$TSCONFIG" <<CONF
 CONF
 trap 'rm -f "$TSCONFIG"' EXIT
 
-if [[ ! -f "$TARGET_DIR/README.tsx" ]]; then
-  echo "No README.tsx found in $TARGET_DIR"
+if [[ ! -f "$SRC_FILE" ]]; then
+  echo "No $(basename "$SRC_FILE") found in $(dirname "$SRC_FILE")"
   exit 1
 fi
 
 # Generate markdown from TSX
 # Filter the spurious "directory mismatch" warning from oven-sh/bun#22023
-output=$(bun run --tsconfig-override "$TSCONFIG" "$TARGET_DIR/README.tsx" 2> >(grep -v "Internal error: directory mismatch" >&2))
+output=$(bun run --tsconfig-override "$TSCONFIG" "$SRC_FILE" 2> >(grep -v "Internal error: directory mismatch" >&2))
 
 if [[ "${usage_check}" == "true" ]]; then
-  if [[ ! -f "$TARGET_DIR/README.md" ]]; then
-    echo "README.md does not exist. Run 'readme build' to generate it."
+  if [[ ! -f "$OUT_FILE" ]]; then
+    echo "$(basename "$OUT_FILE") does not exist. Run 'readme build' to generate it."
     exit 1
   fi
 
-  if ! diff -u "$TARGET_DIR/README.md" <(echo "$output") > /dev/null 2>&1; then
-    echo "README.md is out of date. Run 'readme build' to update it."
+  if ! diff -u "$OUT_FILE" <(echo "$output") > /dev/null 2>&1; then
+    echo "$(basename "$OUT_FILE") is out of date. Run 'readme build' to update it."
     echo ""
-    diff -u "$TARGET_DIR/README.md" <(echo "$output") || true
+    diff -u "$OUT_FILE" <(echo "$output") || true
     exit 1
   fi
 
-  echo "README.md is up to date."
+  echo "$(basename "$OUT_FILE") is up to date."
   exit 0
 fi
 
 # Write output
-echo "$output" > "$TARGET_DIR/README.md"
-echo "Generated README.md"
+mkdir -p "$(dirname "$OUT_FILE")"
+echo "$output" > "$OUT_FILE"
+echo "Generated $(basename "$OUT_FILE")"

--- a/test/build.bats
+++ b/test/build.bats
@@ -33,3 +33,58 @@ TSX
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "README.md is up to date"
 }
+
+# --- --file / --output ---
+
+# Write a second TSX source under the target repo (optionally in a subdir).
+make_guide() {
+  local rel="$1" word="${2:-Guide}"
+  mkdir -p "$TARGET_REPO/$(dirname "$rel")"
+  cat > "$TARGET_REPO/$rel" <<TSX
+/** @jsxImportSource jsx-md */
+import { Heading } from "readme/src/components";
+const readme = <Heading level={1}>$word</Heading>;
+console.log(readme);
+TSX
+}
+
+@test "build --file renders the named TSX to the auto-mapped .md" {
+  make_guide "docs/Guide.tsx" "GuideDoc"
+
+  run bash -c "README_CALLER_PWD='$TARGET_REPO' mise -C '$REPO_DIR' run -q build --file docs/Guide.tsx"
+  [ "$status" -eq 0 ]
+  grep -q "GuideDoc" "$TARGET_REPO/docs/Guide.md"
+  # default README.md must not be created as a side effect
+  [ ! -f "$TARGET_REPO/README.md" ]
+}
+
+@test "build --output overrides the destination" {
+  make_guide "Guide.tsx" "GuideDoc"
+
+  run bash -c "README_CALLER_PWD='$TARGET_REPO' mise -C '$REPO_DIR' run -q build --file Guide.tsx --output out/custom.md"
+  [ "$status" -eq 0 ]
+  grep -q "GuideDoc" "$TARGET_REPO/out/custom.md"
+  [ ! -f "$TARGET_REPO/Guide.md" ]
+}
+
+@test "build --check on a --file target is fail-closed" {
+  make_guide "docs/Guide.tsx" "GuideDoc"
+  README_CALLER_PWD="$TARGET_REPO" mise -C "$REPO_DIR" run -q build --file docs/Guide.tsx
+
+  # fresh -> up to date
+  run bash -c "README_CALLER_PWD='$TARGET_REPO' mise -C '$REPO_DIR' run -q build --file docs/Guide.tsx --check"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Guide.md is up to date"
+
+  # stale -> exit 1
+  printf '\nBROKEN MANUAL EDIT\n' >> "$TARGET_REPO/docs/Guide.md"
+  run bash -c "README_CALLER_PWD='$TARGET_REPO' mise -C '$REPO_DIR' run -q build --file docs/Guide.tsx --check"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "Guide.md is out of date"
+}
+
+@test "build --file errors when the source is missing" {
+  run bash -c "README_CALLER_PWD='$TARGET_REPO' mise -C '$REPO_DIR' run -q build --file docs/Missing.tsx"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "No Missing.tsx found"
+}

--- a/test/build.bats
+++ b/test/build.bats
@@ -88,3 +88,12 @@ TSX
   [ "$status" -ne 0 ]
   echo "$output" | grep -q "No Missing.tsx found"
 }
+
+@test "build without --file ignores stale usage_file env" {
+  make_guide "Other.tsx" "OtherDoc"
+
+  run bash -c "usage_file=Other.tsx README_CALLER_PWD='$TARGET_REPO' mise -C '$REPO_DIR' run -q build"
+  [ "$status" -eq 0 ]
+  grep -q "Hello" "$TARGET_REPO/README.md"
+  [ ! -f "$TARGET_REPO/Other.md" ]
+}


### PR DESCRIPTION
Closes #38 (CLI milestone).

## Summary

`readme build` was directory-based only — it always rendered `README.tsx` → `README.md` in the target dir. This adds two flags so callers can build a specific source:

- `--file <path>` — TSX source to build (default: `README.tsx` in the target dir)
- `--output <path>` — Markdown destination (default: source path with `.tsx` → `.md`)

Paths resolve against `README_CALLER_PWD` (absolute paths honored). The output's parent dir is created before writing. `--check` keeps its fail-closed content comparison against the resolved output.

## Behavior

```bash
readme build                                  # README.tsx -> README.md   (unchanged)
readme build --file docs/Guide.tsx            # -> docs/Guide.md           (auto-mapped)
readme build --file a.tsx --output b.md       # -> b.md
readme build --file docs/Guide.tsx --check    # exit 1 if docs/Guide.md is stale
```

Guard: a non-`.tsx` `--file` without `--output` errors asking for an explicit `--output`.

## Scope

CLI only, per the issue's suggested sequencing. The `v0.3.0` GitHub Action stays directory-based; wiring `file`/`output` action inputs is left as a follow-up.

## Tests

`test/build.bats` gains 4 cases (auto-mapped output, explicit `--output`, fail-closed `--check` on a `--file` target, missing-source error). Existing back-compat tests unchanged.

- `mise run test` → 108 bun + 33 bats, 0 fail
- `mise run build --check` (this repo) → up to date (no component/barrel changes)

## Note for reviewer

Overlaps #39 (`15-build-sources-outputs`), which also edits `.mise/tasks/build` (content-aware write cache). They're compatible — this PR only changes *which* paths are used; whichever lands second takes a small mechanical conflict in the write/`--check` region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)