### PR TITLE
feat: command reference docs generation via readme docs task (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Local pi agent context (not upstream)
+AGENTS.md
+.pi/
+.piac/

--- a/.mise/tasks/docs
+++ b/.mise/tasks/docs
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#MISE description="Generate docs/index.html command reference from .mise/tasks"
+#USAGE flag "--name <text>" help="Project display name (default: target dir basename)"
+#USAGE flag "--tagline <text>" help="One-line project tagline"
+#USAGE flag "--repo <url>" help="GitHub repo URL (default: from git remote)"
+set -e
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if [[ -z "${README_CALLER_PWD:-}" ]]; then
+  echo "Error: README_CALLER_PWD is not set." >&2
+  echo "readme docs must be run through the installed readme shim, or with" >&2
+  echo "README_CALLER_PWD set to the target project directory, e.g.:" >&2
+  echo "  README_CALLER_PWD=\"\$PWD\" mise -C \"$REPO_DIR\" run docs" >&2
+  exit 1
+fi
+
+TARGET_DIR="$README_CALLER_PWD"
+OUTPUT_FILE="$TARGET_DIR/docs/index.html"
+
+if [[ ! -d "$TARGET_DIR/.mise/tasks" ]]; then
+  echo "No .mise/tasks found in $TARGET_DIR — nothing to document."
+  exit 0
+fi
+
+# Bun's --tsconfig-override handles paths resolution only
+TSCONFIG=$(mktemp)
+cat > "$TSCONFIG" <<CONF
+{
+  "compilerOptions": {
+    "paths": {
+      "jsx-md/jsx-runtime": ["$REPO_DIR/src/jsx-runtime.ts"],
+      "jsx-md/jsx-dev-runtime": ["$REPO_DIR/src/jsx-dev-runtime.ts"],
+      "readme": ["$REPO_DIR/index.ts"],
+      "readme/*": ["$REPO_DIR/*"]
+    }
+  }
+}
+CONF
+trap 'rm -f "$TSCONFIG"' EXIT
+
+# Pass task flags as env vars for the generator script
+if [[ -n "${usage_name:-}" ]]; then
+  export DOCS_NAME="$usage_name"
+fi
+
+if [[ -n "${usage_tagline:-}" ]]; then
+  export DOCS_TAGLINE="$usage_tagline"
+fi
+
+if [[ -n "${usage_repo:-}" ]]; then
+  export DOCS_REPO_URL="$usage_repo"
+fi
+
+export README_CALLER_PWD
+
+output=$(bun run --tsconfig-override "$TSCONFIG" "$REPO_DIR/src/docs-generate.ts" 2> >(grep -v "Internal error: directory mismatch" >&2))
+
+# Content-aware write: only rewrite if the content differs (per #15)
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+if [[ -f "$OUTPUT_FILE" ]]; then
+  existing=$(cat "$OUTPUT_FILE")
+  if [[ "$existing" == "$output" ]]; then
+    echo "docs/index.html already up to date."
+    exit 0
+  fi
+fi
+
+echo "$output" > "$OUTPUT_FILE"
+echo "Generated docs/index.html"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>knickknacklabs</title>
+  <style>body {
+      font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+      background: #0d1117;
+      color: #c9d1d9;
+      max-width: 720px;
+      margin: 4rem auto;
+      padding: 0 2rem;
+      line-height: 1.6;
+    }
+    h1 { color: #f0f6fc; font-size: 2rem; margin-bottom: 0.25rem; }
+    h2 { color: #f0f6fc; font-size: 1.2rem; margin-top: 2rem; }
+    .tagline { color: #8b949e; margin-top: 0; }
+    .dim { color: #8b949e; margin-bottom: 0.25rem; }
+    a { color: #58a6ff; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .links { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #30363d; }
+    code {
+      background: #161b22;
+      padding: 0.8rem 1.2rem;
+      display: block;
+      border-radius: 6px;
+      border: 1px solid #30363d;
+      margin: 0.5rem 0 1rem;
+      white-space: pre-wrap;
+      overflow-x: auto;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 0.5rem 0 1rem;
+    }
+    th, td {
+      text-align: left;
+      padding: 0.4rem 0.6rem;
+      border-bottom: 1px solid #21262d;
+    }
+    th { color: #8b949e; font-weight: normal; font-size: 0.85rem; }
+    td:first-child { font-weight: bold; color: #f0f6fc; white-space: nowrap; }
+    .optional { color: #8b949e; font-size: 0.85rem; }</style>
+</head>
+<body>
+<h1>knickknacklabs</h1>
+<h2>build</h2>
+<p class="dim">Generate README.md from README.tsx</p>
+<code>build [--check]</code>
+<table>
+<tr><th>Flag</th><th>Description</th></tr>
+<tr><td>--check</td><td>Check if README.md is up to date (exit 1 if stale)</td></tr>
+</table>
+<h2>docs</h2>
+<p class="dim">Generate docs/index.html command reference from .mise/tasks</p>
+<code>docs [--name <text>] [--tagline <text>] [--repo <url>]</code>
+<table>
+<tr><th>Flag</th><th>Description</th></tr>
+<tr><td>--name &lt;text&gt;</td><td>Project display name (default: target dir basename)</td></tr>
+<tr><td>--tagline &lt;text&gt;</td><td>One-line project tagline</td></tr>
+<tr><td>--repo &lt;url&gt;</td><td>GitHub repo URL (default: from git remote)</td></tr>
+</table>
+<h2>pre-commit:install</h2>
+<p class="dim">Install a git pre-commit hook that keeps README.md in sync</p>
+<code>pre-commit:install [--build] [--check]</code>
+<table>
+<tr><th>Flag</th><th>Description</th></tr>
+<tr><td>--build</td><td>Auto-rebuild and stage README.md on commit</td></tr>
+<tr><td>--check</td><td>Error if README.md is stale on commit</td></tr>
+</table>
+<h2>pre-commit:remove</h2>
+<p class="dim">Remove the readme pre-commit hook</p>
+<code>pre-commit:remove</code>
+<h2>test</h2>
+<p class="dim">Run test suite</p>
+<code>test</code>
+<div class="links"><a href="https://github.com/olavostauros/readme">GitHub</a> &middot; <a href="https://github.com/olavostauros/readme/issues">Issues</a></div>
+</body>
+</html>

--- a/src/docs-generate.ts
+++ b/src/docs-generate.ts
@@ -1,0 +1,59 @@
+// src/docs-generate.ts
+// Entry point for `readme docs` mise task.
+//
+// Reads README_CALLER_PWD, loads mise task metadata, generates a
+// self-contained command-reference HTML page, and prints the result to stdout.
+//
+// The mise task captures stdout, compares with existing output, and
+// writes only on content change (content-aware write per #15).
+
+import { readFileSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { parseTasks } from "./lib/mise";
+import { renderDocsHtml } from "./lib/docs";
+
+function getDefaultRepoUrl(targetDir: string): string | undefined {
+  // Try to read git remote from the target directory
+  const gitConfig = join(targetDir, ".git", "config");
+  if (existsSync(gitConfig)) {
+    const config = readFileSync(gitConfig, "utf-8");
+    const match = config.match(/\[remote "origin"\][\s\S]*?\n\turl = (.+)/);
+    if (match) {
+      let url = match[1].trim();
+      // Convert git@github.com:KnickKnackLabs/repo.git → https form
+      url = url.replace(/^git@([^:]+):/, "https://$1/").replace(/\.git$/, "");
+      return url;
+    }
+  }
+  return undefined;
+}
+
+function getDefaultName(targetDir: string): string {
+  return dirname(targetDir).split("/").pop() || "project";
+}
+
+const targetDir = process.env.README_CALLER_PWD;
+if (!targetDir) {
+  console.error(
+    "Error: README_CALLER_PWD is not set.\n" +
+    "readme docs must be run through the installed readme shim, or with\n" +
+    "README_CALLER_PWD set to the target project directory."
+  );
+  process.exit(1);
+}
+
+const taskDir = join(targetDir, ".mise/tasks");
+if (!existsSync(taskDir)) {
+  console.log(`No .mise/tasks found in ${targetDir} — nothing to document.`);
+  process.exit(0);
+}
+
+const commands = parseTasks(taskDir);
+
+const name = process.env.DOCS_NAME || getDefaultName(targetDir);
+const tagline = process.env.DOCS_TAGLINE || undefined;
+const repoUrl = process.env.DOCS_REPO_URL || getDefaultRepoUrl(targetDir);
+
+const html = renderDocsHtml({ name, tagline, repoUrl, commands });
+
+process.stdout.write(html);

--- a/src/lib/docs.test.ts
+++ b/src/lib/docs.test.ts
@@ -1,0 +1,190 @@
+// src/lib/docs.test.ts
+// Unit tests for the HTML docs renderer.
+
+import { describe, it, expect } from "bun:test";
+import { renderDocsHtml } from "./docs";
+
+describe("renderDocsHtml", () => {
+  it("renders a minimal page with name and no commands", () => {
+    const html = renderDocsHtml({ name: "my-tool", commands: [] });
+    expect(html).toContain("<title>my-tool</title>");
+    expect(html).toContain("<h1>my-tool</h1>");
+    expect(html).toContain("No commands found.");
+  });
+
+  it("renders tagline when provided", () => {
+    const html = renderDocsHtml({ name: "my-tool", tagline: "A great tool", commands: [] });
+    expect(html).toContain("A great tool");
+    expect(html).toContain('class="tagline"');
+  });
+
+  it("renders repo links when repoUrl is provided", () => {
+    const html = renderDocsHtml({
+      name: "my-tool",
+      repoUrl: "https://github.com/KnickKnackLabs/my-tool",
+      commands: [],
+    });
+    expect(html).toContain("https://github.com/KnickKnackLabs/my-tool");
+    expect(html).toContain("GitHub");
+    expect(html).toContain("Issues");
+  });
+
+  it("omits footer when repoUrl is not provided", () => {
+    const html = renderDocsHtml({ name: "my-tool", commands: [] });
+    expect(html).not.toContain('class="links"');
+  });
+
+  it("renders a command heading and description", () => {
+    const html = renderDocsHtml({
+      name: "my-tool",
+      commands: [
+        {
+          name: "build",
+          description: "Build the project",
+          flags: [],
+          args: [],
+          hidden: false,
+        },
+      ],
+    });
+    expect(html).toContain("<h2>build</h2>");
+    expect(html).toContain("Build the project");
+  });
+
+  it("renders boolean flags", () => {
+    const html = renderDocsHtml({
+      name: "my-tool",
+      commands: [
+        {
+          name: "check",
+          description: "Check for issues",
+          flags: [
+            { name: "--check", help: "Verify without writing", isBoolean: true, shortFlag: "-c" },
+          ],
+          args: [],
+          hidden: false,
+        },
+      ],
+    });
+    expect(html).toContain("-c, --check");
+    expect(html).toContain("Verify without writing");
+  });
+
+  it("renders flags with value placeholders", () => {
+    const html = renderDocsHtml({
+      name: "my-tool",
+      commands: [
+        {
+          name: "build",
+          description: "Build the project",
+          flags: [
+            {
+              name: "--out-dir",
+              help: "Output directory",
+              isBoolean: false,
+              valueName: "dir",
+              required: false,
+            },
+          ],
+          args: [],
+          hidden: false,
+        },
+      ],
+    });
+    expect(html).toContain("--out-dir &lt;dir&gt;");
+    expect(html).toContain("Output directory");
+  });
+
+  it("renders required flags with annotation", () => {
+    const html = renderDocsHtml({
+      name: "my-tool",
+      commands: [
+        {
+          name: "install",
+          description: "Install the tool",
+          flags: [
+            { name: "--path", help: "Installation path", isBoolean: false, valueName: "path", required: true },
+          ],
+          args: [],
+          hidden: false,
+        },
+      ],
+    });
+    expect(html).toContain("(required)");
+  });
+
+  it("renders flags with default values", () => {
+    const html = renderDocsHtml({
+      name: "my-tool",
+      commands: [
+        {
+          name: "build",
+          description: "Build the project",
+          flags: [
+            { name: "--format", help: "Output format", isBoolean: false, valueName: "fmt", default: "markdown" },
+          ],
+          args: [],
+          hidden: false,
+        },
+      ],
+    });
+    expect(html).toContain("(default: markdown)");
+  });
+
+  it("renders args with optional markers", () => {
+    const html = renderDocsHtml({
+      name: "my-tool",
+      commands: [
+        {
+          name: "run",
+          description: "Run a task",
+          flags: [],
+          args: [
+            { name: "task", help: "Task name", optional: false },
+            { name: "args", help: "Additional arguments", optional: true },
+          ],
+          hidden: false,
+        },
+      ],
+    });
+    expect(html).toContain("&lt;task&gt;");
+    expect(html).toContain("[args]");
+    expect(html).toContain("(optional)");
+  });
+
+  it("escapes HTML in user-provided content", () => {
+    const html = renderDocsHtml({
+      name: "my<script>alert(1)</script>-tool",
+      tagline: "A <b>bold</b> tool",
+      repoUrl: "https://github.com/KnickKnackLabs/my-tool",
+      commands: [
+        {
+          name: "build",
+          description: "Build & deploy",
+          flags: [
+            { name: "--mode", help: "Mode <dev|prod>", isBoolean: false, valueName: "mode" },
+          ],
+          args: [],
+          hidden: false,
+        },
+      ],
+    });
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("<b>");
+    expect(html).not.toContain("<dev|prod>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&lt;b&gt;");
+    expect(html).toContain("&lt;dev|prod&gt;");
+  });
+
+  it("emits valid HTML document structure", () => {
+    const html = renderDocsHtml({ name: "my-tool", commands: [] });
+    expect(html.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(html).toContain("<html lang=\"en\">");
+    expect(html).toContain("</html>");
+    expect(html).toContain("<head>");
+    expect(html).toContain("</head>");
+    expect(html).toContain("<body>");
+    expect(html).toContain("</body>");
+  });
+});

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,0 +1,190 @@
+// src/lib/docs.ts
+// HTML docs generator for mise file-task command references.
+//
+// Produces a single self-contained HTML file (shiv aesthetic: GitHub-dark,
+// monospace, zero dependencies) from parsed mise task metadata.
+//
+//   import { renderDocsHtml } from "readme/src/lib/docs";
+//   import { parseTasks } from "readme/src/lib/mise";
+//
+//   const commands = parseTasks(".mise/tasks");
+//   const html = renderDocsHtml({ name: "my-tool", commands });
+
+import type { MiseCommand, MiseFlag, MiseArg } from "./mise";
+
+export interface DocsOptions {
+  /** Tool/project name (shown as h1). */
+  name: string;
+  /** Optional one-line tagline. */
+  tagline?: string;
+  /** Optional GitHub repo URL for the footer link. */
+  repoUrl?: string;
+  /** Parsed mise commands to document. */
+  commands: MiseCommand[];
+}
+
+function css(): string {
+  return `body {
+      font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+      background: #0d1117;
+      color: #c9d1d9;
+      max-width: 720px;
+      margin: 4rem auto;
+      padding: 0 2rem;
+      line-height: 1.6;
+    }
+    h1 { color: #f0f6fc; font-size: 2rem; margin-bottom: 0.25rem; }
+    h2 { color: #f0f6fc; font-size: 1.2rem; margin-top: 2rem; }
+    .tagline { color: #8b949e; margin-top: 0; }
+    .dim { color: #8b949e; margin-bottom: 0.25rem; }
+    a { color: #58a6ff; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .links { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #30363d; }
+    code {
+      background: #161b22;
+      padding: 0.8rem 1.2rem;
+      display: block;
+      border-radius: 6px;
+      border: 1px solid #30363d;
+      margin: 0.5rem 0 1rem;
+      white-space: pre-wrap;
+      overflow-x: auto;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 0.5rem 0 1rem;
+    }
+    th, td {
+      text-align: left;
+      padding: 0.4rem 0.6rem;
+      border-bottom: 1px solid #21262d;
+    }
+    th { color: #8b949e; font-weight: normal; font-size: 0.85rem; }
+    td:first-child { font-weight: bold; color: #f0f6fc; white-space: nowrap; }
+    .optional { color: #8b949e; font-size: 0.85rem; }`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function renderFlagName(flag: MiseFlag): string {
+  let result = flag.shortFlag ? `${flag.shortFlag}, ` : "";
+  result += flag.name;
+  if (flag.valueName) result += ` <${flag.valueName}>`;
+  return result;
+}
+
+function renderCommandHtml(cmd: MiseCommand): string {
+  const parts: string[] = [];
+
+  // Command heading
+  parts.push(`<h2>${escapeHtml(cmd.name)}</h2>`);
+
+  // Description
+  if (cmd.description) {
+    parts.push(`<p class="dim">${escapeHtml(cmd.description)}</p>`);
+  }
+
+  // Usage line
+  const usageParts = [escapeHtml(cmd.name)];
+  // Flags always appear optional in usage synopsis
+  for (const flag of cmd.flags) {
+    if (flag.isBoolean) {
+      usageParts.push(`[${escapeHtml(flag.name)}]`);
+    } else {
+      const placeholder = flag.valueName ? ` <${flag.valueName}>` : "";
+      usageParts.push(`[${escapeHtml(flag.name)}${placeholder}]`);
+    }
+  }
+  for (const arg of cmd.args) {
+    if (arg.optional) {
+      usageParts.push(escapeHtml(`[${arg.name}]`));
+    } else {
+      usageParts.push(escapeHtml(`<${arg.name}>`));
+    }
+  }
+  parts.push(`<code>${usageParts.join(" ")}</code>`);
+
+  // Flags table
+  if (cmd.flags.length > 0) {
+    parts.push(`<table>`);
+    parts.push(`<tr><th>Flag</th><th>Description</th></tr>`);
+    for (const flag of cmd.flags) {
+      const flagStr = renderFlagName(flag);
+      const helpParts: string[] = [escapeHtml(flag.help)];
+      if (flag.default !== undefined) helpParts.push(`(default: ${escapeHtml(flag.default)})`);
+      if (flag.required) helpParts.push("(required)");
+      parts.push(`<tr><td>${escapeHtml(flagStr)}</td><td>${helpParts.join(" ")}</td></tr>`);
+    }
+    parts.push(`</table>`);
+  }
+
+  // Args
+  if (cmd.args.length > 0) {
+    parts.push(`<table>`);
+    parts.push(`<tr><th>Arg</th><th>Description</th></tr>`);
+    for (const arg of cmd.args) {
+      const desc = arg.optional
+        ? `${escapeHtml(arg.help)} <span class="optional">(optional)</span>`
+        : escapeHtml(arg.help);
+      parts.push(`<tr><td>${escapeHtml(arg.name)}</td><td>${desc}</td></tr>`);
+    }
+    parts.push(`</table>`);
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Generate a self-contained HTML document listing mise commands
+ * as a command reference, matching the shiv GitHub-dark aesthetic.
+ */
+export function renderDocsHtml(opts: DocsOptions): string {
+  const { name, tagline, repoUrl, commands } = opts;
+
+  const bodyParts: string[] = [];
+
+  // Header
+  bodyParts.push(`<h1>${escapeHtml(name)}</h1>`);
+  if (tagline) {
+    bodyParts.push(`<p class="tagline">${escapeHtml(tagline)}</p>`);
+  }
+
+  // Commands
+  if (commands.length === 0) {
+    bodyParts.push(`<p class="dim">No commands found.</p>`);
+  } else {
+    for (const cmd of commands) {
+      bodyParts.push(renderCommandHtml(cmd));
+    }
+  }
+
+  // Footer
+  if (repoUrl) {
+    bodyParts.push(`<div class="links">` +
+      `<a href="${escapeHtml(repoUrl)}">GitHub</a>` +
+      ` &middot; ` +
+      `<a href="${escapeHtml(repoUrl)}/issues">Issues</a>` +
+      `</div>`);
+  }
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(name)}</title>
+  <style>${css()}</style>
+</head>
+<body>
+${bodyParts.join("\n")}
+</body>
+</html>
+`;
+}

--- a/src/lib/mise.test.ts
+++ b/src/lib/mise.test.ts
@@ -1,0 +1,138 @@
+import { expect, test, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, mkdir, writeFile, rm } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import { parseTasks, countBatsTests } from "./mise";
+
+describe("parseTasks", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "readme-mise-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const task = async (rel: string, body: string) => {
+    const full = join(dir, rel);
+    await mkdir(join(full, ".."), { recursive: true });
+    await writeFile(full, body);
+  };
+
+  test("parses description, a boolean flag, and a valued flag with short/required/default", async () => {
+    await task(
+      "build",
+      `#!/usr/bin/env bash
+#MISE description="Build the thing"
+#USAGE flag "--check" help="Exit 1 if stale"
+#USAGE flag "-o --out-dir <dir>" help="Where to write" default="dist" required=#true
+set -e
+`,
+    );
+
+    const [cmd] = parseTasks(dir);
+    expect(cmd.name).toBe("build");
+    expect(cmd.description).toBe("Build the thing");
+
+    const check = cmd.flags.find((f) => f.name === "--check")!;
+    expect(check.isBoolean).toBe(true);
+    expect(check.help).toBe("Exit 1 if stale");
+    expect(check.valueName).toBeUndefined();
+
+    const out = cmd.flags.find((f) => f.name === "--out-dir")!;
+    expect(out.isBoolean).toBe(false);
+    expect(out.shortFlag).toBe("-o");
+    expect(out.valueName).toBe("dir");
+    expect(out.default).toBe("dist");
+    expect(out.required).toBe(true);
+  });
+
+  test("distinguishes required <arg> from optional [arg]", async () => {
+    await task(
+      "run",
+      `#MISE description="Run it"
+#USAGE arg "<input>" help="Source file"
+#USAGE arg "[output]" help="Destination"
+`,
+    );
+
+    const [cmd] = parseTasks(dir);
+    expect(cmd.args).toEqual([
+      { name: "input", help: "Source file", optional: false },
+      { name: "output", help: "Destination", optional: true },
+    ]);
+  });
+
+  test("walks nested dirs into ':'-joined names", async () => {
+    await task("pre-commit/install", `#MISE description="Install hook"\n`);
+    await task("pre-commit/remove", `#MISE description="Remove hook"\n`);
+
+    const names = parseTasks(dir).map((c) => c.name);
+    expect(names).toContain("pre-commit:install");
+    expect(names).toContain("pre-commit:remove");
+  });
+
+  test("excludes hidden tasks and dot/underscore-prefixed entries", async () => {
+    await task("visible", `#MISE description="Shown"\n`);
+    await task("secret", `#MISE description="Nope"\n#MISE hide=true\n`);
+    await task("_helper", `#MISE description="Helper"\n`);
+    await task(".dotfile", `#MISE description="Dotfile"\n`);
+
+    const names = parseTasks(dir).map((c) => c.name);
+    expect(names).toEqual(["visible"]);
+  });
+
+  test("returns results sorted by name", async () => {
+    await task("zebra", `#MISE description="z"\n`);
+    await task("apple", `#MISE description="a"\n`);
+    await task("mango", `#MISE description="m"\n`);
+
+    expect(parseTasks(dir).map((c) => c.name)).toEqual(["apple", "mango", "zebra"]);
+  });
+
+  test("returns [] for a missing directory", () => {
+    expect(parseTasks(join(dir, "does-not-exist"))).toEqual([]);
+  });
+
+  test("parses this repo's own .mise/tasks (dogfood)", () => {
+    const tasks = parseTasks(join(import.meta.dir, "../../.mise/tasks"));
+    const names = tasks.map((t) => t.name);
+    expect(names).toContain("build");
+    expect(names).toContain("pre-commit:install");
+
+    const build = tasks.find((t) => t.name === "build")!;
+    expect(build.flags.some((f) => f.name === "--check")).toBe(true);
+  });
+});
+
+describe("countBatsTests", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "readme-bats-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("counts @test across multiple .bats files and lists only .bats", async () => {
+    await writeFile(
+      join(dir, "a.bats"),
+      `@test "one" {\n  true\n}\n@test "two" {\n  true\n}\n`,
+    );
+    await writeFile(join(dir, "b.bats"), `@test "three" {\n  true\n}\n`);
+    await writeFile(join(dir, "helpers.bash"), `@test "not counted" {}\n`);
+
+    const { count, files } = countBatsTests(dir);
+    expect(count).toBe(3);
+    expect(files.sort()).toEqual(["a.bats", "b.bats"]);
+  });
+
+  test("returns zero for a missing directory", () => {
+    expect(countBatsTests(join(dir, "nope"))).toEqual({ count: 0, files: [] });
+  });
+});

--- a/src/lib/mise.ts
+++ b/src/lib/mise.ts
@@ -1,0 +1,172 @@
+// Shared parsing helpers for mise file-tasks.
+//
+// mise file-tasks carry metadata in `#MISE` and `#USAGE` comment headers (the
+// jdx/usage spec). README.tsx files across repos kept reimplementing the same
+// parser to auto-generate a command/flags table, plus a `@test` counter for a
+// "tests passing" badge. This consolidates both.
+//
+// mise-specific, so it lives in src/lib and is deliberately NOT re-exported from
+// the main "readme" barrel — codebases that aren't mise-based don't need it.
+//
+//   import { parseTasks, countBatsTests } from "readme/src/lib/mise";
+//
+//   const tasks = parseTasks(".mise/tasks");          // MiseCommand[]
+//   const { count, files } = countBatsTests("test");  // { count, files }
+
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join } from "path";
+
+export interface MiseFlag {
+  /** Long form, e.g. "--check". */
+  name: string;
+  /** Short form if declared, e.g. "-c". */
+  shortFlag?: string;
+  /** Value placeholder for flags that take an argument, e.g. "dir" for `--out-dir <dir>`. */
+  valueName?: string;
+  help: string;
+  required?: boolean;
+  default?: string;
+  /** True when the flag takes no value (`valueName` is absent). */
+  isBoolean: boolean;
+}
+
+export interface MiseArg {
+  name: string;
+  help: string;
+  optional: boolean;
+}
+
+export interface MiseCommand {
+  /** Nested directories are joined with ":", e.g. "pre-commit:install". */
+  name: string;
+  description: string;
+  flags: MiseFlag[];
+  args: MiseArg[];
+  hidden: boolean;
+}
+
+export interface BatsTestCount {
+  count: number;
+  files: string[];
+}
+
+type UsageAttrs = Record<string, string | boolean>;
+
+// Parse the trailing attributes of a #USAGE line, order-independently:
+//   help="..."   default="..."   required=#true
+function parseUsageAttrs(rest: string): UsageAttrs {
+  const attrs: UsageAttrs = {};
+  const attrRe = /(\w[\w-]*)=(?:"([^"]*)"|#(true|false)|([^\s]+))/g;
+  for (const match of rest.matchAll(attrRe)) {
+    const [, key, quoted, bool, bare] = match;
+    if (bool) {
+      attrs[key] = bool === "true";
+    } else {
+      attrs[key] = quoted ?? bare ?? "";
+    }
+  }
+  return attrs;
+}
+
+function stringAttr(attrs: UsageAttrs, key: string): string | undefined {
+  const value = attrs[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function parseTaskFile(filepath: string, name: string): MiseCommand {
+  const lines = readFileSync(filepath, "utf-8").split("\n");
+
+  const description =
+    lines.find((l) => l.startsWith("#MISE description="))
+      ?.match(/#MISE description="(.+)"/)?.[1] ?? "";
+
+  const hidden = lines.some((l) => l.includes("#MISE hide=true"));
+
+  const flags: MiseFlag[] = [];
+  const args: MiseArg[] = [];
+
+  for (const line of lines) {
+    const flagMatch = line.match(
+      /#USAGE flag "(-[\w-]+ )?--(\w[\w-]*)(?:\s+<([\w-]+)>)?"(.*)$/,
+    );
+    if (flagMatch) {
+      const shortFlag = flagMatch[1]?.trim();
+      const flagName = flagMatch[2].replace(/_/g, "-");
+      const valueName = flagMatch[3];
+      const attrs = parseUsageAttrs(flagMatch[4] || "");
+      const required = attrs.required === true;
+      flags.push({
+        name: `--${flagName}`,
+        shortFlag,
+        valueName,
+        help: stringAttr(attrs, "help") ?? "",
+        required: required || undefined,
+        default: stringAttr(attrs, "default"),
+        isBoolean: !valueName,
+      });
+      continue;
+    }
+
+    const argMatch = line.match(/#USAGE arg "([<\[])([\w-]+)([>\]])"(.*)$/);
+    if (argMatch) {
+      const attrs = parseUsageAttrs(argMatch[4] || "");
+      args.push({
+        name: argMatch[2],
+        help: stringAttr(attrs, "help") ?? "",
+        optional: argMatch[1] === "[",
+      });
+    }
+  }
+
+  return { name, description, flags, args, hidden };
+}
+
+// Recursively collect commands. Nested directories become a ":"-joined prefix
+// (matching mise's own task naming, e.g. pre-commit/install → pre-commit:install).
+function walkTasks(dir: string, prefix: string): MiseCommand[] {
+  const results: MiseCommand[] = [];
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".") || entry.name.startsWith("_")) continue;
+    const taskName = prefix ? `${prefix}:${entry.name}` : entry.name;
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      results.push(...walkTasks(fullPath, taskName));
+    } else {
+      results.push(parseTaskFile(fullPath, taskName));
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Parse every mise file-task under `taskDir` (e.g. ".mise/tasks").
+ * Walks nested directories, skips dotfiles / underscore-prefixed helpers and
+ * hidden tasks (`#MISE hide=true`), and returns commands sorted by name.
+ * Returns `[]` if the directory does not exist.
+ */
+export function parseTasks(taskDir: string): MiseCommand[] {
+  if (!existsSync(taskDir)) return [];
+  return walkTasks(taskDir, "")
+    .filter((command) => !command.hidden)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Count `@test` declarations across the `.bats` files in `testDir`.
+ * Returns the total `count` and the list of `.bats` `files` found.
+ * Returns `{ count: 0, files: [] }` if the directory does not exist.
+ */
+export function countBatsTests(testDir: string): BatsTestCount {
+  if (!existsSync(testDir)) return { count: 0, files: [] };
+
+  const files = readdirSync(testDir).filter((f) => f.endsWith(".bats"));
+  const count = files.reduce((total, file) => {
+    const src = readFileSync(join(testDir, file), "utf-8");
+    return total + (src.match(/@test "/g)?.length ?? 0);
+  }, 0);
+
+  return { count, files };
+}

--- a/test/docs.bats
+++ b/test/docs.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+# readme docs task test suite
+
+REPO_DIR="$BATS_TEST_DIRNAME/.."
+
+setup() {
+  export TARGET_REPO="$BATS_TEST_TMPDIR/project"
+  mkdir -p "$TARGET_REPO/.mise/tasks"
+
+  # Create a minimal mise task to document
+  cat > "$TARGET_REPO/.mise/tasks/build" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Build the project"
+#USAGE flag "--check" help="Verify output is up to date"
+TASK
+  chmod +x "$TARGET_REPO/.mise/tasks/build"
+}
+
+@test "docs requires README_CALLER_PWD even when mise -C runs from the package" {
+  run bash -c "cd '$TARGET_REPO' && mise -C '$REPO_DIR' run -q docs"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "README_CALLER_PWD is not set"
+}
+
+@test "docs generates docs/index.html in the target directory" {
+  README_CALLER_PWD="$TARGET_REPO" mise -C "$REPO_DIR" run -q docs
+
+  [ -f "$TARGET_REPO/docs/index.html" ]
+  grep -q "build" "$TARGET_REPO/docs/index.html"
+  grep -q "Build the project" "$TARGET_REPO/docs/index.html"
+}
+
+@test "docs is content-aware — skips rewrite when content unchanged" {
+  README_CALLER_PWD="$TARGET_REPO" mise -C "$REPO_DIR" run -q docs
+  # Capture mtime
+  mtime_before=$(stat -c %Y "$TARGET_REPO/docs/index.html")
+
+  # Run again
+  run bash -c "README_CALLER_PWD='$TARGET_REPO' mise -C '$REPO_DIR' run -q docs"
+  mtime_after=$(stat -c %Y "$TARGET_REPO/docs/index.html")
+
+  echo "$output" | grep -q "already up to date"
+  [ "$mtime_before" -eq "$mtime_after" ]
+}
+
+@test "docs uses --name flag for the h1 title" {
+  run bash -c "README_CALLER_PWD='$TARGET_REPO' mise -C '$REPO_DIR' run -q docs --name 'My Awesome Tool'"
+  [ "$status" -eq 0 ]
+  grep -q "<h1>My Awesome Tool</h1>" "$TARGET_REPO/docs/index.html"
+}
+
+@test "docs uses --tagline flag" {
+  run bash -c "README_CALLER_PWD='$TARGET_REPO' mise -C '$REPO_DIR' run -q docs --name 'tool' --tagline 'A fantastic CLI'"
+  [ "$status" -eq 0 ]
+  grep -q "A fantastic CLI" "$TARGET_REPO/docs/index.html"
+}
+
+@test "docs uses --repo flag for footer links" {
+  run bash -c "README_CALLER_PWD='$TARGET_REPO' mise -C '$REPO_DIR' run -q docs --name 'tool' --repo 'https://github.com/user/tool'"
+  [ "$status" -eq 0 ]
+  grep -q "https://github.com/user/tool" "$TARGET_REPO/docs/index.html"
+  grep -q "Issues" "$TARGET_REPO/docs/index.html"
+}
+
+@test "docs shows noop message when target has no .mise/tasks" {
+  TARGET_WITHOUT_TASKS="$BATS_TEST_TMPDIR/empty"
+  mkdir -p "$TARGET_WITHOUT_TASKS"
+
+  run bash -c "README_CALLER_PWD='$TARGET_WITHOUT_TASKS' mise -C '$REPO_DIR' run -q docs"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "nothing to document"
+}
+
+@test "docs renders flags with value placeholders" {
+  # Add a task with value flag
+  cat > "$TARGET_REPO/.mise/tasks/deploy" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Deploy to environment"
+#USAGE flag "--env <name>" help="Target environment" required=#true
+TASK
+  chmod +x "$TARGET_REPO/.mise/tasks/deploy"
+
+  README_CALLER_PWD="$TARGET_REPO" mise -C "$REPO_DIR" run -q docs
+
+  grep -q "deploy" "$TARGET_REPO/docs/index.html"
+  grep -q "required" "$TARGET_REPO/docs/index.html"
+}
+
+@test "docs renders args" {
+  # Add a task with args
+  cat > "$TARGET_REPO/.mise/tasks/run" <<'TASK'
+#!/usr/bin/env bash
+#MISE description="Run a command"
+#USAGE arg "<cmd>" help="Command to run"
+#USAGE arg "[args]" help="Additional arguments"
+TASK
+  chmod +x "$TARGET_REPO/.mise/tasks/run"
+
+  README_CALLER_PWD="$TARGET_REPO" mise -C "$REPO_DIR" run -q docs
+
+  grep -q "run" "$TARGET_REPO/docs/index.html"
+  grep -q "(optional)" "$TARGET_REPO/docs/index.html"
+}


### PR DESCRIPTION
Closes readme#19

## Summary

Adds a `readme docs` mise task that generates a self-contained `docs/index.html` command reference from `.mise/tasks/` metadata. Designed for GitHub Pages deployment from the `/docs` path.

## What it does

```bash
# Generate command reference for any KKL repo
README_CALLER_PWD="/path/to/repo" mise run docs

# With custom metadata
README_CALLER_PWD="/path/to/repo" mise run docs \
  --name "My Tool" \
  --tagline "A fantastic CLI" \
  --repo "https://github.com/user/repo"

# If no .mise/tasks — noop with a clear message
```

## Architecture

| Layer | File | Purpose |
|---|---|---|
| Library | `src/lib/docs.ts` | `renderDocsHtml({ name, tagline?, repoUrl?, commands }): string` — pure template, zero deps |
| Entry point | `src/docs-generate.ts` | Reads `README_CALLER_PWD`, calls `parseTasks` + `renderDocsHtml`, prints HTML to stdout |
| Task | `.mise/tasks/docs` | Cross-repo mise task with `--name`/`--tagline`/`--repo` flags; content-aware write |
| Unit tests | `src/lib/docs.test.ts` | 12 tests — headings, flags, args, escaping, structure |
| Integration | `test/docs.bats` | 9 tests — errors, generation, content-aware, flags, noop |

## Aesthetic

Matches the **shiv** GitHub Pages pattern: single self-contained HTML file, GitHub-dark theme (`#0d1117` bg, `#c9d1d9` text, `#58a6ff` links, `#161b22` code blocks), monospace font, zero dependencies — no framework, no build step.

## Verification

- `bun test`: **98 pass, 0 fail**
- `bats test/`: **35 pass, 0 fail** (9 new docs tests + 26 existing)
- Dogfood: generated this repo's own `docs/index.html` from `.mise/tasks/`
- Content-aware: identical content skips rewrite; mtime unchanged
- Shell syntax: `bash -n .mise/tasks/docs` clean

## Builds on

- **#18 / PR #40** — `parseTasks()` in `src/lib/mise.ts` (this branch is based on that branch; will rebase when #40 merges)
- **#15 / PR #39** — content-aware write pattern from the `build` task